### PR TITLE
Fix placeholder resolving in FileWriter

### DIFF
--- a/tinylog/src/org/pmw/tinylog/writers/FileWriter.java
+++ b/tinylog/src/org/pmw/tinylog/writers/FileWriter.java
@@ -82,7 +82,7 @@ public final class FileWriter implements Writer {
 	 *            Continuing existing file
 	 */
 	FileWriter(final String filename, final Boolean buffered, final Boolean append) {
-		this.filename = filename;
+		this.filename = PathResolver.resolve(filename);
 		this.buffered = buffered == null ? false : buffered;
 		this.append = append == null ? false : append;
 	}


### PR DESCRIPTION
I relied pretty much on the resolving of environment variables in filenames supplied to `FileWriter` and noticed that occasionally the placeholders would not be replaced at all.

My analysis is as follows:

1. Previously not all constructors of `FileWriter` resolved the path.
2. `org.pmw.tinylog.PropertiesLoader#loadWriter` makes use of `java.lang.Class#getDeclaredConstructors`, which, according to the Javadoc, does not return constructors in a particular order, and `org.pmw.tinylog.PropertiesLoader#areCompatible`, which is responsible for making the two signatures 

        FileWriter(java.lang.String, boolean, boolean)                     (1)
        FileWriter(java.lang.String, java.lang.Boolean, java.lang.Boolean) (2)
    
    compare identical.
3. The constructor was chosen at random (with higher chance of selecting (1)), replacing environment variables most of the time, but leaving the filename as-is in some instances using (2).
 
My initial fix is adding the missing call to `PathResolver.resolve`.  
I doubt there is actually a need for maintaining both constructors. Maybe there are even more defects  due to the fact that `PropertiesLoader` does not consistently select the same constructor, like missing  optional values causing an NPE when coerced to one of the primitive types.  I'll leave it up to you to amend the PR with a removal.