### PR TITLE
Add support for timestamp token for outputting time in milliseconds or seconds.

### DIFF
--- a/tinylog-impl/src/main/java/org/tinylog/pattern/FormatPatternParser.java
+++ b/tinylog-impl/src/main/java/org/tinylog/pattern/FormatPatternParser.java
@@ -120,6 +120,8 @@ public final class FormatPatternParser {
 	private static Token createPlainToken(final String name, final String configuration) {
 		if (name.equals("date")) {
 			return createDateToken(configuration);
+		} else if ("timestamp".equals(name)) {
+			return new TimestampToken(configuration);
 		} else if ("pid".equals(name)) {
 			return new ProcessIdToken();
 		} else if ("thread".equals(name)) {

--- a/tinylog-impl/src/main/java/org/tinylog/pattern/TimestampToken.java
+++ b/tinylog-impl/src/main/java/org/tinylog/pattern/TimestampToken.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Martin Winandy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.tinylog.pattern;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.tinylog.core.LogEntry;
+import org.tinylog.core.LogEntryValue;
+
+/**
+ * Token for outputting the time of issue of a log entry as a Unix timestamp.
+ */
+final class TimestampToken implements Token {
+
+	private static final long SECONDS_DIVISOR = 1000;
+
+	private final boolean useMilliseconds;
+
+	/**	*/
+	TimestampToken() {
+		this.useMilliseconds = false;
+	}
+
+	/**
+	 * @param unit
+	 *            Unit of timestamp (e.g. milliseconds)
+	 *            Invalid value defaults to seconds.
+	 */
+	TimestampToken(final String unit) {
+		this.useMilliseconds = "milliseconds".equals(unit);
+	}
+
+	@Override
+	public Collection<LogEntryValue> getRequiredLogEntryValues() {
+		return Collections.singletonList(LogEntryValue.DATE);
+	}
+
+	@Override
+	public void render(final LogEntry logEntry, final StringBuilder builder) {
+		long timestamp = logEntry.getTimestamp().toDate().getTime();
+
+		if (useMilliseconds) {
+			builder.append(timestamp);
+		} else {
+			builder.append(timestamp / SECONDS_DIVISOR);
+		}
+	}
+
+	@Override
+	public void apply(final LogEntry logEntry, final PreparedStatement statement, final int index) throws SQLException {
+		statement.setTimestamp(index, logEntry.getTimestamp().toSqlTimestamp());
+	}
+
+}

--- a/tinylog-impl/src/test/java/org/tinylog/pattern/FormatPatternParserTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/pattern/FormatPatternParserTest.java
@@ -75,6 +75,34 @@ public final class FormatPatternParserTest {
 	}
 
 	/**
+	 * Verifies that {@code {timestamp}} can be parsed and the returned token will output the timestamp of issue, in seconds.
+	 */
+	@Test
+	public void timestampWithDefaultPattern() {
+		LocalDate date = LocalDate.of(1985, 06, 03);
+		assertThat(render("timestamp", LogEntryBuilder.empty().date(date).create())).isEqualTo("486604800");
+	}
+
+	/**
+	 * Verifies that {@code {timestamp}} can be parsed with a specified milliseconds pattern and the returned token will output the date of
+	 * issue as a timestamp in milliseconds.
+	 */
+	@Test
+	public void timestampWithMillisecondsPattern() {
+		LocalDate date = LocalDate.of(1985, 06, 03);
+		assertThat(render("timestamp: milliseconds", LogEntryBuilder.empty().date(date).create())).isEqualTo("486604800000");
+	}
+
+	/**
+	 * Verifies that the default seconds pattern will be used, if the custom pattern for {@code {timestamp}} is invalid.
+	 */
+	@Test
+	public void timestampWithUnknownPattern() {
+		LocalDate date = LocalDate.of(1985, 06, 03);
+		assertThat(render("timestamp: inval'd", LogEntryBuilder.empty().date(date).create())).isEqualTo("486604800");
+	}
+
+	/**
 	 * Verifies that {@code {pid}} can be parsed and the returned token will output the process ID.
 	 */
 	@Test

--- a/tinylog-impl/src/test/java/org/tinylog/pattern/TimestampTokenTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/pattern/TimestampTokenTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019 Martin Winandy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.tinylog.pattern;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+import org.junit.Test;
+import org.tinylog.core.LogEntry;
+import org.tinylog.core.LogEntryValue;
+import org.tinylog.util.LogEntryBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link TimestampToken}.
+ */
+public class TimestampTokenTest {
+
+	/**
+	 * Verifies that {@link LogEntryValue#DATE} is the only required log entry value.
+	 */
+	@Test
+	public void requiredLogEntryValues() {
+		TimestampToken token = new TimestampToken();
+		assertThat(token.getRequiredLogEntryValues()).containsOnly(LogEntryValue.DATE);
+	}
+
+	/**
+	 * Verifies that milliseconds pattern will be rendered correctly for a {@link StringBuilder}.
+	 */
+	@Test
+	public void renderMillisecondsTimestampPattern() {
+		TimestampToken token = new TimestampToken("milliseconds");
+
+		assertThat(render(token, LocalDateTime.of(2016, 01, 01, 00, 00))).isEqualTo("1451606400000");
+		assertThat(render(token, LocalDateTime.of(2016, 01, 01, 12, 00))).isEqualTo("1451649600000");
+		assertThat(render(token, LocalDateTime.of(2016, 01, 02, 00, 00))).isEqualTo("1451692800000");
+	}
+
+	/**
+	 * Verifies that the rendered default pattern equals timestamp in seconds.
+	 */
+	@Test
+	public void renderDefaultPattern() {
+		TimestampToken token = new TimestampToken();
+
+		assertThat(render(token, LocalDateTime.of(2016, 06, 30, 12, 00))).isEqualTo("1467288000");
+		assertThat(render(token, LocalDateTime.of(2016, 06, 30, 12, 15))).isEqualTo("1467288900");
+	}
+
+	/**
+	 * Verifies that the current time will be added as a {@link Timestamp} to a {@link PreparedStatement}.
+	 *
+	 * @throws SQLException
+	 *             Failed to add value to prepared SQL statement
+	 */
+	@Test
+	public void applyTimestamp() throws SQLException {
+		TimestampToken token = new TimestampToken();
+		LocalDateTime now = LocalDateTime.now();
+
+		PreparedStatement statement = mock(PreparedStatement.class);
+		token.apply(createLogEntry(now), statement, 1);
+		verify(statement).setTimestamp(1, Timestamp.valueOf(now));
+	}
+
+	/**
+	 * Renders a token.
+	 *
+	 * @param token
+	 *            Token to render
+	 * @param timestamp
+	 *            Date and time of issue for log entry
+	 * @return Result text
+	 */
+	private static String render(final Token token, final LocalDateTime timestamp) {
+		StringBuilder builder = new StringBuilder();
+		token.render(createLogEntry(timestamp), builder);
+		return builder.toString();
+	}
+
+	/**
+	 * Creates a log entry that contains a date.
+	 *
+	 * @param date
+	 *            Date for log entry
+	 * @return Filled log entry
+	 */
+	private static LogEntry createLogEntry(final LocalDateTime date) {
+		return LogEntryBuilder.empty().date(date).create();
+	}
+
+}


### PR DESCRIPTION
I only provided support for seconds or milliseconds. Was considering microseconds as well, in which case I would probably just determine a divisor for calculating the value in the constructor instead of just a boolean indicating whether or not to use seconds.