### PR TITLE
Add linktolatest option for RollingFileWriter

### DIFF
--- a/tinylog-impl/pom.xml
+++ b/tinylog-impl/pom.xml
@@ -75,7 +75,12 @@
 			<groupId>org.tinylog</groupId>
 			<artifactId>tinylog-api</artifactId>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>animal-sniffer-annotations</artifactId>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/tinylog-impl/src/test/java/org/tinylog/writers/RollingFileWriterTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/writers/RollingFileWriterTest.java
@@ -481,4 +481,92 @@ public final class RollingFileWriterTest {
 		assertThat(writer).isInstanceOf(RollingFileWriter.class);
 	}
 
+
+	/**
+	 * Verifies that symlink to new log segment is created at startup.
+	 *
+	 * @throws IOException
+	 *             Failed access to temporary folder or files
+	 */
+	@Test
+	public void createSymlinkToLatestAtStartUp() throws IOException {
+		File file1 = folder.newFile("0");
+		File file2 = folder.newFile("1");
+		File file3 = folder.newFile("2");
+		File file4 = folder.newFile("3");
+		File linkToLatest = folder.newFile("latest");
+
+		file1.setLastModified(0);
+		file2.setLastModified(1000);
+		file3.setLastModified(2000);
+		file4.setLastModified(3000);
+
+		Map<String, String> properties = new HashMap<>();
+		properties.put("file", new File(folder.getRoot(), "{count}").getAbsolutePath());
+		properties.put("latest", linkToLatest.getAbsolutePath());
+		properties.put("format", "{message}");
+		properties.put("policies", "size: 1MB");
+		properties.put("backups", "2");
+
+		RollingFileWriter writer = new RollingFileWriter(properties);
+		try {
+			assertThat(linkToLatest.getCanonicalPath()).isEqualTo(file4.getCanonicalPath());
+			assertThat(file1).doesNotExist();
+			assertThat(file2).exists();
+			assertThat(file3).exists();
+			assertThat(file4).exists();
+		} finally {
+			writer.close();
+		}
+	}
+
+	/**
+	 * Verifies that obsolete backup files will be deleted when rolling log file.
+	 *
+	 * @throws IOException
+	 *             Failed access to temporary folder or files
+	 */
+	@Test
+	public void updateSymlinkToLatestAtRollOver() throws IOException {
+		File file1 = folder.newFile("0");
+		File file2 = folder.newFile("1");
+		File file3 = folder.newFile("2");
+		File file4 = folder.newFile("3");
+		File file5 = folder.newFile("4");
+		File linkToLatest = folder.newFile("latest");
+
+		file1.setLastModified(0);
+		file2.setLastModified(1000);
+		file3.setLastModified(2000);
+		file4.setLastModified(3000);
+		file5.delete();
+
+		Map<String, String> properties = new HashMap<>();
+		properties.put("file", new File(folder.getRoot(), "{count}").getAbsolutePath());
+		properties.put("latest", linkToLatest.getAbsolutePath());
+		properties.put("format", "{message}");
+		properties.put("policies", "size: 10");
+		properties.put("backups", "3");
+
+		RollingFileWriter writer = new RollingFileWriter(properties);
+
+		assertThat(file1).exists();
+		assertThat(file2).exists();
+		assertThat(file3).exists();
+		assertThat(file4).exists();
+		assertThat(file5).doesNotExist();
+
+		writer.write(LogEntryBuilder.empty().message("First").create());
+		writer.write(LogEntryBuilder.empty().message("Second").create());
+
+		assertThat(file1).doesNotExist();
+		assertThat(file2).exists();
+		assertThat(file3).exists();
+		assertThat(file4).hasContent("First" + NEW_LINE);
+		assertThat(file5).hasContent("Second" + NEW_LINE);
+
+		assertThat(linkToLatest.getCanonicalPath()).isEqualTo(file5.getCanonicalPath());
+
+		writer.close();
+	}
 }

--- a/tinylog-impl/src/test/java/org/tinylog/writers/RollingFileWriterTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/writers/RollingFileWriterTest.java
@@ -481,45 +481,6 @@ public final class RollingFileWriterTest {
 		assertThat(writer).isInstanceOf(RollingFileWriter.class);
 	}
 
-
-	/**
-	 * Verifies that symlink to new log segment is created at startup.
-	 *
-	 * @throws IOException
-	 *             Failed access to temporary folder or files
-	 */
-	@Test
-	public void createSymlinkToLatestAtStartUp() throws IOException {
-		File file1 = folder.newFile("0");
-		File file2 = folder.newFile("1");
-		File file3 = folder.newFile("2");
-		File file4 = folder.newFile("3");
-		File linkToLatest = folder.newFile("latest");
-
-		file1.setLastModified(0);
-		file2.setLastModified(1000);
-		file3.setLastModified(2000);
-		file4.setLastModified(3000);
-
-		Map<String, String> properties = new HashMap<>();
-		properties.put("file", new File(folder.getRoot(), "{count}").getAbsolutePath());
-		properties.put("latest", linkToLatest.getAbsolutePath());
-		properties.put("format", "{message}");
-		properties.put("policies", "size: 1MB");
-		properties.put("backups", "2");
-
-		RollingFileWriter writer = new RollingFileWriter(properties);
-		try {
-			assertThat(linkToLatest.getCanonicalPath()).isEqualTo(file4.getCanonicalPath());
-			assertThat(file1).doesNotExist();
-			assertThat(file2).exists();
-			assertThat(file3).exists();
-			assertThat(file4).exists();
-		} finally {
-			writer.close();
-		}
-	}
-
 	/**
 	 * Verifies that obsolete backup files will be deleted when rolling log file.
 	 *


### PR DESCRIPTION
see https://github.com/pmwmedia/tinylog/issues/149

I'm not sure how to implement the assertions in the test.  The build is not working on my machine (javac 11.0.7)

```
tinylog/tinylog-api/src/main/java/org/tinylog/runtime/LegacyJavaRuntime.java:[58,43] cannot find symbol
[ERROR]   symbol:   class Reflection
[ERROR]   location: package sun.reflect
```

If you find the idea acceptable, could you please help me with this part?  Thank you!