### PR TITLE
Fix issue #158 (Access to providers and writers)

### DIFF
--- a/tinylog-api/src/main/java/org/tinylog/provider/BundleLoggingProvider.java
+++ b/tinylog-api/src/main/java/org/tinylog/provider/BundleLoggingProvider.java
@@ -121,8 +121,7 @@ final class BundleLoggingProvider implements LoggingProvider {
 	 * Get all logging providers stored inside this bundle.
 	 * @return All logging providers.
 	 */
-	List<LoggingProvider> getLoggingProviders()
-	{
-		return  Arrays.asList(loggingProviders);		
+	List<LoggingProvider> getLoggingProviders() {
+		return Arrays.asList(loggingProviders);		
 	}
 }

--- a/tinylog-api/src/main/java/org/tinylog/provider/BundleLoggingProvider.java
+++ b/tinylog-api/src/main/java/org/tinylog/provider/BundleLoggingProvider.java
@@ -14,7 +14,9 @@
 package org.tinylog.provider;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.tinylog.Level;
 import org.tinylog.format.MessageFormatter;
@@ -114,4 +116,13 @@ final class BundleLoggingProvider implements LoggingProvider {
 		return new BundleContextProvider(contextProviders);
 	}
 
+	
+	/**
+	 * Get all logging providers stored inside this bundle.
+	 * @return All logging providers.
+	 */
+	List<LoggingProvider> getLoggingProviders()
+	{
+		return  Arrays.asList(loggingProviders);		
+	}
 }

--- a/tinylog-api/src/main/java/org/tinylog/provider/ProviderRegistry.java
+++ b/tinylog-api/src/main/java/org/tinylog/provider/ProviderRegistry.java
@@ -13,7 +13,10 @@
 
 package org.tinylog.provider;
 
+import java.text.SimpleDateFormat;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 import org.tinylog.Level;
 import org.tinylog.configuration.Configuration;
@@ -51,6 +54,26 @@ public final class ProviderRegistry {
 	 */
 	public static LoggingProvider getLoggingProvider() {
 		return loggingProvider;
+	}
+	
+	/**
+	 * Get all loaded logging providers.  
+	 * 
+	 * <p>
+	 * If the logging provider is a {@link BundleLoggingProvider} resolve its contents and return them.
+	 * </p>
+	 * 
+	 * @return The list of all logging providers.
+	 */
+	public static List<LoggingProvider> getLoggingProviders() {
+		if (loggingProvider instanceof BundleLoggingProvider)
+		{
+			return ((BundleLoggingProvider)loggingProvider).getLoggingProviders();
+		}
+		else
+		{
+			return Collections.singletonList(loggingProvider);
+		}
 	}
 
 	/**

--- a/tinylog-api/src/main/java/org/tinylog/provider/ProviderRegistry.java
+++ b/tinylog-api/src/main/java/org/tinylog/provider/ProviderRegistry.java
@@ -13,7 +13,6 @@
 
 package org.tinylog.provider;
 
-import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -66,12 +65,9 @@ public final class ProviderRegistry {
 	 * @return The list of all logging providers.
 	 */
 	public static List<LoggingProvider> getLoggingProviders() {
-		if (loggingProvider instanceof BundleLoggingProvider)
-		{
-			return ((BundleLoggingProvider)loggingProvider).getLoggingProviders();
-		}
-		else
-		{
+		if (loggingProvider instanceof BundleLoggingProvider) {
+			return ((BundleLoggingProvider) loggingProvider).getLoggingProviders();
+		} else {
 			return Collections.singletonList(loggingProvider);
 		}
 	}

--- a/tinylog-api/src/main/java/org/tinylog/provider/ProviderRegistry.java
+++ b/tinylog-api/src/main/java/org/tinylog/provider/ProviderRegistry.java
@@ -56,7 +56,7 @@ public final class ProviderRegistry {
 	}
 	
 	/**
-	 * Get all loaded logging providers.  
+	 * Gets all loaded logging providers.  
 	 * 
 	 * <p>
 	 * If the logging provider is a {@link BundleLoggingProvider} resolve its contents and return them.

--- a/tinylog-api/src/test/java/org/tinylog/provider/BundleLoggingProviderTest.java
+++ b/tinylog-api/src/test/java/org/tinylog/provider/BundleLoggingProviderTest.java
@@ -14,11 +14,8 @@
 package org.tinylog.provider;
 
 import org.junit.Test;
-import org.powermock.reflect.Whitebox;
 import org.tinylog.Level;
 import org.tinylog.format.MessageFormatter;
-import org.tinylog.provider.ProviderRegistryTest.LoggingProviderOne;
-import org.tinylog.provider.ProviderRegistryTest.LoggingProviderTwo;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -166,12 +163,12 @@ public final class BundleLoggingProviderTest {
 	@Test
 	public void resolveBundleLoggingProviders() {
 		init(Level.TRACE, Level.TRACE);
-		assertThat( ((BundleLoggingProvider)bundle).getLoggingProviders())
-		.hasSize(2)
-		.hasOnlyElementsOfType(LoggingProvider.class);
+		assertThat(((BundleLoggingProvider) bundle).getLoggingProviders())
+			.hasSize(2)
+			.hasOnlyElementsOfType(LoggingProvider.class);
 	}
 
-	
+
 	/**
 	 * Verifies that {@code shutdown()} method invokes {@code shutdown()} methods from underlying logging providers.
 	 * 

--- a/tinylog-api/src/test/java/org/tinylog/provider/BundleLoggingProviderTest.java
+++ b/tinylog-api/src/test/java/org/tinylog/provider/BundleLoggingProviderTest.java
@@ -14,8 +14,11 @@
 package org.tinylog.provider;
 
 import org.junit.Test;
+import org.powermock.reflect.Whitebox;
 import org.tinylog.Level;
 import org.tinylog.format.MessageFormatter;
+import org.tinylog.provider.ProviderRegistryTest.LoggingProviderOne;
+import org.tinylog.provider.ProviderRegistryTest.LoggingProviderTwo;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -154,7 +157,21 @@ public final class BundleLoggingProviderTest {
 		verify(first).log(BundleContextProvider.class.getName(), "technical", Level.INFO, exception, formatter, "Test", 42);
 		verify(second).log(BundleContextProvider.class.getName(), "technical", Level.INFO, exception, formatter, "Test", 42);
 	}
+	
+	
+	/**
+	 * Verifies that {@code getMinimumLevel(String)} method returns the minimum severity level of underlying logging
+	 * providers, if all have the same minimum severity level for an tag.
+	 */
+	@Test
+	public void resolveBundleLoggingProviders() {
+		init(Level.TRACE, Level.TRACE);
+		assertThat( ((BundleLoggingProvider)bundle).getLoggingProviders())
+		.hasSize(2)
+		.hasOnlyElementsOfType(LoggingProvider.class);
+	}
 
+	
 	/**
 	 * Verifies that {@code shutdown()} method invokes {@code shutdown()} methods from underlying logging providers.
 	 * 

--- a/tinylog-api/src/test/java/org/tinylog/provider/ProviderRegistryTest.java
+++ b/tinylog-api/src/test/java/org/tinylog/provider/ProviderRegistryTest.java
@@ -116,7 +116,6 @@ public final class ProviderRegistryTest {
 			.hasAtLeastOneElementOfType(LoggingProviderTwo.class);
 	}
 	
-	
 	/**
 	 * Verifies that one or more (combined) providers can be obtained again.
 	 *
@@ -125,7 +124,6 @@ public final class ProviderRegistryTest {
 	 */
 	@Test
 	public void multipleProvidersGetter() throws Exception {
-		
 		FileSystem.createServiceFile(LoggingProvider.class, LoggingProviderOne.class.getName(), LoggingProviderTwo.class.getName());
 		
 		Object saveProvider = Whitebox.getInternalState(ProviderRegistry.class, "loggingProvider");
@@ -147,7 +145,6 @@ public final class ProviderRegistryTest {
 		
 		assertThat(ProviderRegistry.getLoggingProvider()).isInstanceOf(NopLoggingProvider.class);
 	}
-	
 
 	/**
 	 * Verifies that a defined logging provider can be loaded if multiple are available.

--- a/tinylog-api/src/test/java/org/tinylog/provider/ProviderRegistryTest.java
+++ b/tinylog-api/src/test/java/org/tinylog/provider/ProviderRegistryTest.java
@@ -13,12 +13,6 @@
 
 package org.tinylog.provider;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.powermock.api.mockito.PowerMockito.spy;
-import static org.powermock.api.mockito.PowerMockito.when;
-
-import java.util.List;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -32,6 +26,10 @@ import org.tinylog.configuration.Configuration;
 import org.tinylog.format.MessageFormatter;
 import org.tinylog.rules.SystemStreamCollector;
 import org.tinylog.util.FileSystem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
  * Tests for {@link ProviderRegistry}.
@@ -136,16 +134,16 @@ public final class ProviderRegistryTest {
 		LoggingProvider createdProvider = Whitebox.invokeMethod(ProviderRegistry.class, "loadLoggingProvider");
 		Whitebox.setInternalState(ProviderRegistry.class, "loggingProvider", createdProvider);
 		
-		assertThat( ProviderRegistry.getLoggingProviders())
-		.hasSize(2)
-		.hasAtLeastOneElementOfType(LoggingProviderOne.class)
-		.hasAtLeastOneElementOfType(LoggingProviderTwo.class);	
+		assertThat(ProviderRegistry.getLoggingProviders())
+			.hasSize(2)
+			.hasAtLeastOneElementOfType(LoggingProviderOne.class)
+			.hasAtLeastOneElementOfType(LoggingProviderTwo.class);	
 		
 		Whitebox.setInternalState(ProviderRegistry.class, "loggingProvider", saveProvider);
 		
-		assertThat( ProviderRegistry.getLoggingProviders())
-		.hasSize(1)
-		.hasAtLeastOneElementOfType(NopLoggingProvider.class);	
+		assertThat(ProviderRegistry.getLoggingProviders())
+			.hasSize(1)
+			.hasAtLeastOneElementOfType(NopLoggingProvider.class);	
 		
 		assertThat(ProviderRegistry.getLoggingProvider()).isInstanceOf(NopLoggingProvider.class);
 	}

--- a/tinylog-impl/src/main/java/org/tinylog/core/TinylogLoggingProvider.java
+++ b/tinylog-impl/src/main/java/org/tinylog/core/TinylogLoggingProvider.java
@@ -411,9 +411,11 @@ public class TinylogLoggingProvider implements LoggingProvider {
 	}
 	
 	/**
-	 * Get all writers of the provider which respond to the given tag. A null tag is possible for the generic writer.
-	 * @param tag The tag to find
-	 * @return The writer objects.
+	 * Gets all writers of the provider which respond to the given tag. A null tag is possible for the generic writer.
+	 *
+	 * @param tag
+	 *            The tag to find
+	 * @return All writers
 	 */
 	public Collection<Writer> getWriters(final String tag) {
 		Set<Writer> collectedWriters = new HashSet<Writer>(); 
@@ -429,8 +431,9 @@ public class TinylogLoggingProvider implements LoggingProvider {
 	}
 	
 	/**
-	 * Get all writers of the provider.
-	 * @return The writes.
+	 * Gets all writers of the provider.
+	 * 
+	 * @return All writers
 	 */
 	public Collection<Writer> getWriters() {
 		Set<Writer> collectedWriters = new HashSet<Writer>(); 

--- a/tinylog-impl/src/main/java/org/tinylog/core/TinylogLoggingProvider.java
+++ b/tinylog-impl/src/main/java/org/tinylog/core/TinylogLoggingProvider.java
@@ -17,6 +17,7 @@ import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -408,5 +409,42 @@ public class TinylogLoggingProvider implements LoggingProvider {
 			}
 		}
 	}
+	
+	/**
+	 * Get all writers of the provider which respond to the given tag. A null tag is possible for the generic writer.
+	 * @param tag The tag to find
+	 * @return The writer objects.
+	 */
+	public Collection<Writer> getWriters(final String tag)
+	{
+		Set<Writer> collectedWriters = new HashSet<Writer>(); 
+		int tagIndex = getTagIndex(tag);
+		if (tagIndex > knownTags.size()) 
+		{
+			return collectedWriters;
+		}
+		
+		for (int j = 0; j < writers[tagIndex].length; ++j) {
+			collectedWriters.addAll(writers[tagIndex][j]);
+		}
+		return collectedWriters;
+	}
+	
+	/**
+	 * Get all writers of the provider.
+	 * @return The writes.
+	 */
+	public Collection<Writer> getWriters()
+	{
+		Set<Writer> collectedWriters = new HashSet<Writer>(); 
+		
+		for (int tagIndex = 0; tagIndex < writers.length; ++tagIndex) {
+			for (int levelIndex = 0; levelIndex <writers[tagIndex].length; ++levelIndex) {
+				collectedWriters.addAll(writers[tagIndex][levelIndex]);
+			}
+		}
+
+		return collectedWriters;
+	}	
 
 }

--- a/tinylog-impl/src/main/java/org/tinylog/core/TinylogLoggingProvider.java
+++ b/tinylog-impl/src/main/java/org/tinylog/core/TinylogLoggingProvider.java
@@ -415,12 +415,10 @@ public class TinylogLoggingProvider implements LoggingProvider {
 	 * @param tag The tag to find
 	 * @return The writer objects.
 	 */
-	public Collection<Writer> getWriters(final String tag)
-	{
+	public Collection<Writer> getWriters(final String tag) {
 		Set<Writer> collectedWriters = new HashSet<Writer>(); 
 		int tagIndex = getTagIndex(tag);
-		if (tagIndex > knownTags.size()) 
-		{
+		if (tagIndex > knownTags.size()) {
 			return collectedWriters;
 		}
 		
@@ -434,12 +432,11 @@ public class TinylogLoggingProvider implements LoggingProvider {
 	 * Get all writers of the provider.
 	 * @return The writes.
 	 */
-	public Collection<Writer> getWriters()
-	{
+	public Collection<Writer> getWriters() {
 		Set<Writer> collectedWriters = new HashSet<Writer>(); 
 		
 		for (int tagIndex = 0; tagIndex < writers.length; ++tagIndex) {
-			for (int levelIndex = 0; levelIndex <writers[tagIndex].length; ++levelIndex) {
+			for (int levelIndex = 0; levelIndex < writers[tagIndex].length; ++levelIndex) {
 				collectedWriters.addAll(writers[tagIndex][levelIndex]);
 			}
 		}

--- a/tinylog-impl/src/test/java/org/tinylog/core/TinylogLoggingProviderTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/core/TinylogLoggingProviderTest.java
@@ -13,13 +13,7 @@
 
 package org.tinylog.core;
 
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonMap;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
-import static org.tinylog.util.Maps.doubletonMap;
-import static org.tinylog.util.ResultObserver.waitFor;
-
+import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
@@ -50,6 +44,12 @@ import org.tinylog.util.StorageWriter;
 import org.tinylog.util.Strings;
 import org.tinylog.writers.ConsoleWriter;
 import org.tinylog.writers.Writer;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.tinylog.util.Maps.doubletonMap;
+import static org.tinylog.util.ResultObserver.waitFor;
 
 /**
  * Tests for {@link TinylogLoggingProvider}.
@@ -658,7 +658,6 @@ public final class TinylogLoggingProviderTest {
 
 	}
 	
-	
 	/**
 	 * Tests to obtain the writers from the provider.
 	 */
@@ -702,23 +701,16 @@ public final class TinylogLoggingProviderTest {
 			assertThat(provider.getWriters("TAG3")).hasSize(2);
 			
 			Condition<Writer> condition = new Condition<Writer>() {
-			    @Override
-			    public boolean matches(Writer o) {
-			        return o.getClass() == ConsoleWriter.class;
-			    }};
-				assertThat(provider.getWriters("TAG1")).areExactly(1, condition);
-				assertThat(provider.getWriters("TAG2")).areExactly(1, condition);
-				assertThat(provider.getWriters("TAG3")).areExactly(2, condition);
-				assertThat(provider.getWriters()).areExactly(4, condition);
-			
+				@Override
+				public boolean matches(final Writer o) {
+					return o.getClass() == ConsoleWriter.class;
+				} };
+			assertThat(provider.getWriters("TAG1")).areExactly(1, condition);
+			assertThat(provider.getWriters("TAG2")).areExactly(1, condition);
+			assertThat(provider.getWriters("TAG3")).areExactly(2, condition);
+			assertThat(provider.getWriters()).areExactly(4, condition);
 		}
-
-
-
-
 	}
-
-	
 
 	/**
 	 * Tests for receiving context provider.
@@ -793,15 +785,7 @@ public final class TinylogLoggingProviderTest {
 		 */
 		@BeforeClass
 		public static void configure() {
-			try
-			{
-				Configuration.replace(doubletonMap("writer", EvilWriter.class.getName(), "autoshutdown", "false"));
-				fail("Excepted UnsupportedOperationException on reconfgure");
-			}
-			catch(UnsupportedOperationException e)
-			{
-				// Latest version of Tinylog throws an exception in this case
-			}
+			Configuration.replace(doubletonMap("writer", EvilWriter.class.getName(), "autoshutdown", "false"));
 		}
 
 		/**
@@ -810,13 +794,10 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void logging() {
 			provider.log(1, null, Level.INFO, null, null, "Hello World!");
-			assertThat(systemStream.consumeStandardOutput())
-			.containsOnlyOnce("INFO")
-			.containsOnlyOnce("Hello World!");
-//			assertThat(systemStream.consumeErrorOutput())
-//					.containsOnlyOnce("ERROR")
-//					.containsOnlyOnce(IOException.class.getName())
-//					.containsOnlyOnce("Hello World!");
+			assertThat(systemStream.consumeErrorOutput())
+					.containsOnlyOnce("ERROR")
+					.containsOnlyOnce(IOException.class.getName())
+					.containsOnlyOnce("Hello World!");
 		}
 
 		/**
@@ -828,7 +809,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void shutdown() throws InterruptedException {
 			provider.shutdown();
-//			assertThat(systemStream.consumeErrorOutput()).containsOnlyOnce("ERROR").containsOnlyOnce(IOException.class.getName());
+			assertThat(systemStream.consumeErrorOutput()).containsOnlyOnce("ERROR").containsOnlyOnce(IOException.class.getName());
 		}
 
 	}


### PR DESCRIPTION
 Allow access to writer and provider #158  fixed.

Compared to the previous pull request this version follows now the Tinylog style checks. 

The getWriters(TAG, LEVEL) is not implemented as it seems of too little use.

Also the issue with the Exception vs ERROR in the test did not occur. Maybe a wrong configuration. So the test is like before. But maybe check whether it shouild be an Exception or an error string in case I got it wrong.