### PR TITLE
Implementation for Multi-Tag Writer #164

### DIFF
--- a/tinylog-impl/src/main/java/org/tinylog/core/ConfigurationParser.java
+++ b/tinylog-impl/src/main/java/org/tinylog/core/ConfigurationParser.java
@@ -77,7 +77,7 @@ public final class ConfigurationParser {
 			String tag = Configuration.get(writerProperty + ".tag");
 			if (tag != null && !tag.isEmpty() && !tag.equals("-")) {
 				String[] tagArray = tag.split(",");
-				for (String tagArrayItem:tagArray) {
+				for (String tagArrayItem : tagArray) {
 					tagArrayItem = tagArrayItem.trim();
 					if (!tags.contains(tagArrayItem) && !tagArrayItem.isEmpty()) {
 						tags.add(tagArrayItem);

--- a/tinylog-impl/src/main/java/org/tinylog/core/ConfigurationParser.java
+++ b/tinylog-impl/src/main/java/org/tinylog/core/ConfigurationParser.java
@@ -75,8 +75,14 @@ public final class ConfigurationParser {
 		List<String> tags = new ArrayList<String>();
 		for (String writerProperty : Configuration.getSiblings("writer").keySet()) {
 			String tag = Configuration.get(writerProperty + ".tag");
-			if (tag != null && !tag.isEmpty() && !tag.equals("-") && !tags.contains(tag)) {
-				tags.add(tag);
+			if (tag != null && !tag.isEmpty() && !tag.equals("-")) {
+				String[] tagArray = tag.split(",");
+				for (String tagArrayItem:tagArray) {
+					tagArrayItem = tagArrayItem.trim();
+					if (!tags.contains(tagArrayItem) && !tagArrayItem.isEmpty()) {
+						tags.add(tagArrayItem);
+					}
+				}
 			}
 		}
 		return tags;
@@ -161,7 +167,14 @@ public final class ConfigurationParser {
 				} else if (tag.equals("-")) {
 					addWriter(writer, matrix, 0, level);
 				} else {
-					addWriter(writer, matrix, tags.indexOf(tag) + 1, level);
+					String[] tagArray = tag.split(",");
+					for (String tagArrayItem : tagArray) {
+						tagArrayItem = tagArrayItem.trim(); 
+						if (!tagArrayItem.isEmpty()) {
+							addWriter(writer, matrix, tags.indexOf(tagArrayItem) + 1, level);
+						}
+					}
+					
 				}
 			}
 		}

--- a/tinylog-impl/src/test/java/org/tinylog/core/ConfigurationParserTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/core/ConfigurationParserTest.java
@@ -192,6 +192,18 @@ public final class ConfigurationParserTest {
 	}
 
 	/**
+	 * Verifies that multiple tags from a writer will be found.
+	 */
+	@Test
+	public void writerWithMultipleTags() {
+		Configuration.set("writer", "console");
+		Configuration.set("writer.tag", " system , , backup  , test, , "); // Test also odd tag entries
+
+		List<String> tags = ConfigurationParser.getTags();
+		assertThat(tags).containsExactlyInAnyOrder("system", "backup", "test");
+	}
+
+	/**
 	 * Verifies that tags can be read from multiple writers and each tag will be returned only once.
 	 */
 	@Test
@@ -336,6 +348,33 @@ public final class ConfigurationParserTest {
 		assertThat(writers[1]).allSatisfy(collection -> assertThat(collection).isEmpty());
 	}
 
+	/**
+	 * Verifies that a single tagged writer with multiple tags will be created and assigned correctly.
+	 */
+	@Test
+	public void singleMultipleTaggedWriter() {
+		Configuration.set("writer", "console");
+		Configuration.set("writer.tag", " system , , backup  , test, , "); // Test also unusual tag entries
+		List<String> tags = ConfigurationParser.getTags();
+		Collection<Writer>[][] writers = ConfigurationParser.createWriters(tags, Level.TRACE, false);
+
+		assertThat(writers)
+			.hasSize(5)
+			.allSatisfy(element -> assertThat(element).hasSize(5));
+
+		assertThat(writers[0]).allSatisfy(collection -> assertThat(collection).isEmpty());
+		assertThat(writers[1]).allSatisfy(collection -> {
+			assertThat(collection).hasSize(1).allSatisfy(writer -> assertThat(writer).isInstanceOf(ConsoleWriter.class));
+		});
+		assertThat(writers[2]).allSatisfy(collection -> {
+			assertThat(collection).hasSize(1).allSatisfy(writer -> assertThat(writer).isInstanceOf(ConsoleWriter.class));
+		});
+		assertThat(writers[3]).allSatisfy(collection -> {
+			assertThat(collection).hasSize(1).allSatisfy(writer -> assertThat(writer).isInstanceOf(ConsoleWriter.class));
+		});
+		assertThat(writers[4]).allSatisfy(collection -> assertThat(collection).isEmpty());
+	}
+	
 	/**
 	 * Verifies that two tagged writers will be created and assigned correctly.
 	 *


### PR DESCRIPTION
### Description
Implementation of #164 multi tag writer as discussed in the issue #164. A writer can have more then one (comma separated) tag entry.

Linked issue: #164 

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Code style follows the tinylog standard
- [x] All classes and methods have Javadoc
- [x] Changes are covered by JUnit tests including corner cases, errors, and exception handling
- [x] Maven build works including compiling, tests, and checks (`mvn verify`)
- [x] Changes are committed by a verified email address that is assigned to the GitHub account (https://github.com/settings/emails)

### Documentation

Additions or amendments for the [public documentation](https://github.com/pmwmedia/tinylog/wiki/Documentation):

```markdown
The user manual has to be update to reflect the muilti tag situation.
A tag can be now writer.tag = a,b,c
```

### Agreements

- [x] I agree that my changes will be published under the terms of the [Apache License 2.0](https://github.com/pmwmedia/tinylog/blob/v2.0/license.txt)
- [x] I agree that my GitHub user name will be published in the release notes
