### PR TITLE
Check method to obtain frozen status of configuration.

### DIFF
--- a/tinylog-api/src/main/java/org/tinylog/configuration/Configuration.java
+++ b/tinylog-api/src/main/java/org/tinylog/configuration/Configuration.java
@@ -375,4 +375,13 @@ public final class Configuration {
 		return builder.toString();
 	}
 
+	/**
+	 * Checks whether the configuration is already frozen.
+	 *
+	 * @return {@code true} if the configuration is frozen, otherwise {@code false}
+	 */
+	public static boolean isFrozen() {
+		return frozen;
+	}
+
 }

--- a/tinylog-api/src/test/java/org/tinylog/configuration/ConfigurationTest.java
+++ b/tinylog-api/src/test/java/org/tinylog/configuration/ConfigurationTest.java
@@ -626,6 +626,17 @@ public final class ConfigurationTest {
 	}
 
 	/**
+	 * Verifies that the frozen status of the configuration can be read and changes after freezing.
+	 */
+	@Test
+	public void checkFrozen() {
+		Configuration.set("freeze", "test");
+		assertThat(Configuration.isFrozen()).isFalse();
+		assertThat(Configuration.get("freeze")).isEqualTo("test");
+		assertThat(Configuration.isFrozen()).isTrue();
+	}
+	
+	/**
 	 * Triggers (re-)loading properties.
 	 *
 	 * @param path


### PR DESCRIPTION
### Description

A minimal addition to the `Configuration `object to query its status, i.e. whether it is **frozen** or not.

**Reason is:** In a test szenario unit tests create the logger configuration programmatically. Since mutliple configurations of the logger lead to an exception it has to be traced with a static setting in the tests if the logger was setup. Since the `Configuration `knows this already it might be useful to make it posssible to query the status.

If you do not see this necessary, just reject the pull request it can be worked around locally so it is an optional change.

Linked issue: #000 (It is so small I did not open an issue but can do that if desired).

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Code style follows the tinylog standard
- [x] All classes and methods have Javadoc
- [x] Changes are covered by JUnit tests including corner cases, errors, and exception handling
- [x] Maven build works including compiling, tests, and checks (`mvn verify`)
- [x] Changes are committed by a verified email address that is assigned to the GitHub account (https://github.com/settings/emails)

### Documentation

Additions or amendments for the [public documentation](https://github.com/pmwmedia/tinylog/wiki/Documentation):

```markdown
None
```

### Agreements

- [x] I agree that my changes will be published under the terms of the [Apache License 2.0](https://github.com/pmwmedia/tinylog/blob/v2.0/license.txt)
- [x] I agree that my GitHub user name will be published in the release notes
