### PR TITLE
Allow Multi Level for writer Multi tag feature #174.

### DIFF
--- a/tinylog-impl/src/main/java/org/tinylog/core/ConfigurationParser.java
+++ b/tinylog-impl/src/main/java/org/tinylog/core/ConfigurationParser.java
@@ -73,7 +73,7 @@ public final class ConfigurationParser {
 			if (tag != null && !tag.isEmpty() && !tag.equals("-")) {
 				String[] tagArray = tag.split(",");
 				for (String tagArrayItem : tagArray) {
-					tagArrayItem = tagArrayItem.trim();
+					tagArrayItem = tagArrayItem.replaceAll("@.*", "").trim();
 					if (!tags.contains(tagArrayItem) && !tagArrayItem.isEmpty()) {
 						tags.add(tagArrayItem);
 					}

--- a/tinylog-impl/src/main/java/org/tinylog/core/TinylogLoggingConfiguration.java
+++ b/tinylog-impl/src/main/java/org/tinylog/core/TinylogLoggingConfiguration.java
@@ -85,7 +85,6 @@ public class TinylogLoggingConfiguration {
 			}
 
 			configuration.put("ID", entry.getKey());
-
 			configuration.put("writingthread", Boolean.toString(writingThread));
 
 			Writer writer = loader.create(entry.getValue(), configuration);
@@ -100,8 +99,18 @@ public class TinylogLoggingConfiguration {
 					String[] tagArray = tag.split(",");
 					for (String tagArrayItem : tagArray) {
 						tagArrayItem = tagArrayItem.trim(); 
+						String[] tagLevelItem = tagArrayItem.split("@", 2);
+						Level currentLevel;
+						String currentTag;
+						if (tagLevelItem.length == 1) {
+							currentTag = tagArrayItem;
+							currentLevel = level;
+						} else {
+							currentTag = tagLevelItem[0].trim();
+							currentLevel = ConfigurationParser.parse(tagLevelItem[1].trim(), level);	
+						}
 						if (!tagArrayItem.isEmpty()) {
-							addWriter(writer, matrix, tags.indexOf(tagArrayItem) + 1, level);
+							addWriter(writer, matrix, tags.indexOf(currentTag) + 1, currentLevel);
 						}
 					}
 				}

--- a/tinylog-impl/src/test/java/org/tinylog/core/ConfigurationParserTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/core/ConfigurationParserTest.java
@@ -194,6 +194,18 @@ public final class ConfigurationParserTest {
 	}
 
 	/**
+	 * Verifies that multiple tags with levels will be found (i.e. the levels are ignored).
+	 */
+	@Test
+	public void writerWithMultipleTagsWithLevels() {
+		Configuration.set("writer", "console");
+		Configuration.set("writer.tag", " system@INFO , backup , test@TRACE "); 
+
+		List<String> tags = ConfigurationParser.getTags();
+		assertThat(tags).containsExactlyInAnyOrder("system", "backup", "test");
+	}
+	
+	/**
 	 * Verifies that tags can be read from multiple writers and each tag will be returned only once.
 	 */
 	@Test

--- a/tinylog-impl/src/test/java/org/tinylog/core/TinylogLoggingConfigurationTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/core/TinylogLoggingConfigurationTest.java
@@ -163,6 +163,46 @@ public final class TinylogLoggingConfigurationTest {
 	}
 	
 	/**
+	 * Verifies that a single tagged writer with multiple tags and levels will be created and assigned correctly.
+	 */
+	@Test
+	public void singleMultipleTaggedWriterWithLevels() {
+		Configuration.set("writer", "console");
+		Configuration.set("writer.level", "ERROR"); // Default level
+		Configuration.set("writer.tag", " system@WARN , , backup  , test@INFO, , "); // Test also unusual tag entries
+		
+		List<String> tags = ConfigurationParser.getTags();
+		TinylogLoggingConfiguration config = new TinylogLoggingConfiguration();
+		Collection<Writer>[][] writers = config.createWriters(tags, Level.TRACE, false);
+
+		assertThat(writers)
+			.hasSize(5)
+			.allSatisfy(element -> assertThat(element).hasSize(5));
+		
+		assertThat(writers[0]).allSatisfy(collection -> assertThat(collection).isEmpty());
+		
+		assertThat(writers[1][Level.TRACE.ordinal()]).isEmpty();
+		assertThat(writers[1][Level.DEBUG.ordinal()]).isEmpty();
+		assertThat(writers[1][Level.INFO.ordinal()]).isEmpty();
+		assertThat(writers[1][Level.WARN.ordinal()]).hasSize(1).allSatisfy(w -> assertThat(w).isInstanceOf(ConsoleWriter.class));
+		assertThat(writers[1][Level.ERROR.ordinal()]).hasSize(1).allSatisfy(w -> assertThat(w).isInstanceOf(ConsoleWriter.class));
+
+		assertThat(writers[2][Level.TRACE.ordinal()]).isEmpty();
+		assertThat(writers[2][Level.DEBUG.ordinal()]).isEmpty();
+		assertThat(writers[2][Level.INFO.ordinal()]).isEmpty();
+		assertThat(writers[2][Level.WARN.ordinal()]).isEmpty();
+		assertThat(writers[2][Level.ERROR.ordinal()]).hasSize(1).allSatisfy(w -> assertThat(w).isInstanceOf(ConsoleWriter.class));
+
+		assertThat(writers[3][Level.TRACE.ordinal()]).isEmpty();
+		assertThat(writers[3][Level.DEBUG.ordinal()]).isEmpty();
+		assertThat(writers[3][Level.INFO.ordinal()]).hasSize(1).allSatisfy(w -> assertThat(w).isInstanceOf(ConsoleWriter.class));
+		assertThat(writers[3][Level.WARN.ordinal()]).hasSize(1).allSatisfy(w -> assertThat(w).isInstanceOf(ConsoleWriter.class));
+		assertThat(writers[3][Level.ERROR.ordinal()]).hasSize(1).allSatisfy(w -> assertThat(w).isInstanceOf(ConsoleWriter.class));
+		
+		assertThat(writers[4]).allSatisfy(collection -> assertThat(collection).isEmpty());
+	}
+	
+	/**
 	 * Verifies that two tagged writers will be created and assigned correctly.
 	 *
 	 * @throws IOException


### PR DESCRIPTION
### Description

Allow the use of different levels for different tags in the multi tag feature.

Linked issue: #174.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Code style follows the tinylog standard
- [x] All classes and methods have Javadoc
- [x] Changes are covered by JUnit tests including corner cases, errors, and exception handling
- [x] Maven build works including compiling, tests, and checks (`mvn verify`)
- [x] Changes are committed by a verified email address that is assigned to the GitHub account (https://github.com/settings/emails)

### Documentation

Additions or amendments for the [public documentation](https://github.com/pmwmedia/tinylog/wiki/Documentation):

```markdown
 Documentation needs to be adapted to the new tag syntax. Old syntax is still valid.
```

### Agreements

- [x] I agree that my changes will be published under the terms of the [Apache License 2.0](https://github.com/pmwmedia/tinylog/blob/v2.0/license.txt)
- [x] I agree that my GitHub user name will be published in the release notes
