### PR TITLE
Allow access to writer and provider (Part II ) #176.

### DIFF
--- a/tinylog-impl/src/main/java/org/tinylog/core/TinylogLoggingProvider.java
+++ b/tinylog-impl/src/main/java/org/tinylog/core/TinylogLoggingProvider.java
@@ -261,7 +261,27 @@ public class TinylogLoggingProvider implements LoggingProvider {
 	}
 	
 	/**
-	 * Gets all writers of the provider which respond to the given tag. A null tag is possible for the generic writer.
+	 * Gets all writers which belong to the given tag and a given level. A null tag is possible for the generic writer.
+	 * 
+	 * @param tag
+	 *            The tag to find
+	 * @param level
+	 *            The level to find
+	 * @return All writers
+	 */
+	public Collection<Writer> getWriters(final String tag, final Level level) {
+		Set<Writer> collectedWriters = new HashSet<Writer>(); 
+		int tagIndex = getTagIndex(tag);
+		if (tagIndex > knownTags.size() || level == Level.OFF) {
+			return collectedWriters;
+		}
+
+		collectedWriters.addAll(writers[tagIndex][level.ordinal()]);
+		return collectedWriters;
+	}
+	
+	/**
+	 * Gets all writers of the provider which belong to the given tag. A null tag is possible for the generic writer.
 	 *
 	 * @param tag
 	 *            The tag to find

--- a/tinylog-impl/src/test/java/org/tinylog/core/TinylogLoggingProviderTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/core/TinylogLoggingProviderTest.java
@@ -668,30 +668,32 @@ public final class TinylogLoggingProviderTest {
 		 */
 		@BeforeClass
 		public static void configure() {
+			Whitebox.setInternalState(Configuration.class, "frozen", false);
 			Configuration.replace(emptyMap());
 
 			Configuration.set("writer1", "console");
 			Configuration.set("writer1.tag", "TAG1");
+			Configuration.set("writer1.level", Level.DEBUG.name());
 			Configuration.set("writer1.format", "{level}: {message}");
 
 			Configuration.set("writer2", "console");
-			Configuration.set("writer2.level", "info");
+			Configuration.set("writer2.level", Level.WARN.name());
 			Configuration.set("writer2.tag", "TAG2");
 			Configuration.set("writer2.format", "{level}: {message}");
 			
 			Configuration.set("writer3", "console");
-			Configuration.set("writer3.level", "info");
+			Configuration.set("writer3.level", Level.INFO.name());
 			Configuration.set("writer3.tag", "TAG3");
 			Configuration.set("writer3.format", "{level}: {message}");
 			
 			Configuration.set("writer4", "console");
-			Configuration.set("writer4.level", "info");
+			Configuration.set("writer4.level", Level.INFO.name());
 			Configuration.set("writer4.tag", "TAG3");
 			Configuration.set("writer4.format", "{level}: {message}");
 		}
 
 		/**
-		 * Verifies that the global minimum severity level for all loggers is {@link Level#TRACE}.
+		 * Verifies that the writers can be obtained from the provider correctly.
 		 */
 		@Test
 		public void checkWriterRetrieval() {
@@ -700,6 +702,20 @@ public final class TinylogLoggingProviderTest {
 			assertThat(provider.getWriters("TAG2")).hasSize(1);
 			assertThat(provider.getWriters("TAG3")).hasSize(2);
 			
+			assertThat(provider.getWriters("TAG1", Level.TRACE)).hasSize(0);
+			assertThat(provider.getWriters("TAG1", Level.DEBUG)).hasSize(1);
+			assertThat(provider.getWriters("TAG1", Level.ERROR)).hasSize(1);
+
+			assertThat(provider.getWriters("TAG2", Level.INFO)).hasSize(0);
+			assertThat(provider.getWriters("TAG2", Level.WARN)).hasSize(1);
+			assertThat(provider.getWriters("TAG2", Level.ERROR)).hasSize(1);
+			
+			assertThat(provider.getWriters("TAG3", Level.DEBUG)).hasSize(0);
+			assertThat(provider.getWriters("TAG3", Level.INFO)).hasSize(2);
+			assertThat(provider.getWriters("TAG3", Level.ERROR)).hasSize(2);
+			
+			assertThat(provider.getWriters("TAG3", Level.OFF)).hasSize(0);			
+
 			Condition<Writer> condition = new Condition<Writer>() {
 				@Override
 				public boolean matches(final Writer o) {

--- a/tinylog-impl/src/test/java/org/tinylog/core/TinylogLoggingProviderTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/core/TinylogLoggingProviderTest.java
@@ -701,6 +701,8 @@ public final class TinylogLoggingProviderTest {
 			assertThat(provider.getWriters("TAG1")).hasSize(1);
 			assertThat(provider.getWriters("TAG2")).hasSize(1);
 			assertThat(provider.getWriters("TAG3")).hasSize(2);
+			assertThat(provider.getWriters("XXX")).hasSize(0);
+			assertThat(provider.getWriters(null)).hasSize(0);
 			
 			assertThat(provider.getWriters("TAG1", Level.TRACE)).hasSize(0);
 			assertThat(provider.getWriters("TAG1", Level.DEBUG)).hasSize(1);
@@ -715,6 +717,7 @@ public final class TinylogLoggingProviderTest {
 			assertThat(provider.getWriters("TAG3", Level.ERROR)).hasSize(2);
 			
 			assertThat(provider.getWriters("TAG3", Level.OFF)).hasSize(0);			
+			assertThat(provider.getWriters("XXX", Level.ERROR)).hasSize(0);			
 
 			Condition<Writer> condition = new Condition<Writer>() {
 				@Override


### PR DESCRIPTION
### Description

Added the third getter by tag and level for writers from the `TinyLogLoggingProvider`.

Linked issue: #176

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Code style follows the tinylog standard
- [x] All classes and methods have Javadoc
- [x] Changes are covered by JUnit tests including corner cases, errors, and exception handling
- [x] Maven build works including compiling, tests, and checks (`mvn verify`)
- [x] Changes are committed by a verified email address that is assigned to the GitHub account (https://github.com/settings/emails)

### Documentation

Additions or amendments for the [public documentation](https://github.com/pmwmedia/tinylog/wiki/Documentation):

```markdown
No documentation change necessary.
```

### Agreements

- [x] I agree that my changes will be published under the terms of the [Apache License 2.0](https://github.com/pmwmedia/tinylog/blob/v2.0/license.txt)
- [x] I agree that my GitHub user name will be published in the release notes
