### PR TITLE
Implementation of Flexible Console Writer Error Level #180.

### DIFF
--- a/tinylog-impl/src/main/java/org/tinylog/writers/ConsoleWriter.java
+++ b/tinylog-impl/src/main/java/org/tinylog/writers/ConsoleWriter.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.tinylog.Level;
+import org.tinylog.core.ConfigurationParser;
 import org.tinylog.core.LogEntry;
 import org.tinylog.core.LogEntryValue;
 import org.tinylog.provider.InternalLogger;
@@ -46,16 +47,32 @@ public final class ConsoleWriter extends AbstractFormatPatternWriter {
 	public ConsoleWriter(final Map<String, String> properties) {
 		super(properties);
 		
+		// Set the default level for stderr logging
+		Level levelStream = Level.WARN;
+		
+		// Check stream property
 		String stream = properties.get("stream");
+		if (stream != null) {
+			// Check whether we have the err@LEVEL syntax
+			String[] streams = stream.split("@", 2);
+			if (streams.length == 2) {
+				levelStream = ConfigurationParser.parse(streams[1], levelStream);
+				if (!streams[0].equals("err")) {
+					InternalLogger.log(Level.ERROR, "Stream with level must be \"err\", \"" + streams[0] + "\" is an invalid name");
+				}
+				stream = null;
+			}
+		}
+		
 		if (stream == null) {
-			errorLevel = Level.WARN;
+			errorLevel = levelStream;
 		} else if ("err".equalsIgnoreCase(stream)) {
 			errorLevel = Level.TRACE;
 		} else if ("out".equalsIgnoreCase(stream)) {
 			errorLevel = Level.OFF;
 		} else {
 			InternalLogger.log(Level.ERROR, "Stream must be \"out\" or \"err\", \"" + stream + "\" is an invalid stream name");
-			errorLevel = Level.WARN;
+			errorLevel = levelStream;
 		}
 	}
 


### PR DESCRIPTION
### Description
Adds the possibility to set the logging level from which the console
writer shall use stderr as output. Default stays at WARN.

Linked issue: #180

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Code style follows the tinylog standard
- [x] All classes and methods have Javadoc
- [x] Changes are covered by JUnit tests including corner cases, errors, and exception handling
- [x] Maven build works including compiling, tests, and checks (`mvn verify`)
- [x] Changes are committed by a verified email address that is assigned to the GitHub account (https://github.com/settings/emails)

### Documentation

Additions or amendments for the [public documentation](https://github.com/pmwmedia/tinylog/wiki/Documentation):

```markdown
Documentation needs to add the err@LEVEL setting, e.g. err@ERROR
```

### Agreements

- [x] I agree that my changes will be published under the terms of the [Apache License 2.0](https://github.com/pmwmedia/tinylog/blob/v2.0/license.txt)
- [x] I agree that my GitHub user name will be published in the release notes
