### PR TITLE
Add support for SLF4J binding via SPI in SLF4J 1.8 onwards

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 		<mockk.version>1.11.0</mockk.version>
 		<powermock.version>2.0.9</powermock.version>
 		<scala.version>2.12.13</scala.version>
-		<slf4j.version>1.7.30</slf4j.version>
+		<slf4j.version>2.0.0-alpha1</slf4j.version>
 
 	</properties>
 

--- a/slf4j-tinylog/src/main/java/org/tinylog/slf4j/TinylogSlf4jServiceProvider.java
+++ b/slf4j-tinylog/src/main/java/org/tinylog/slf4j/TinylogSlf4jServiceProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 Martin Winandy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.tinylog.slf4j;
+
+import org.slf4j.ILoggerFactory;
+import org.slf4j.IMarkerFactory;
+import org.slf4j.helpers.BasicMarkerFactory;
+import org.slf4j.spi.MDCAdapter;
+import org.slf4j.spi.SLF4JServiceProvider;
+
+/**
+ * SPI implementation for SLF4j 1.8+. Replacement mechanism for {@link org.slf4j.impl.StaticLoggerBinder}.
+ */
+public class TinylogSlf4jServiceProvider implements SLF4JServiceProvider {
+
+	/**
+	 * SLF4J API 1.8 and newer is supported.
+	 */
+	public static final String REQUESTED_API_VERSION = "1.8";
+
+	private ILoggerFactory loggerFactory;
+	private IMarkerFactory markerFactory;
+	private MDCAdapter mdcAdapter;
+
+	/** */
+	public TinylogSlf4jServiceProvider() {
+	}
+
+	@Override
+	public ILoggerFactory getLoggerFactory() {
+		return loggerFactory;
+	}
+
+	@Override
+	public IMarkerFactory getMarkerFactory() {
+		return markerFactory;
+	}
+
+	@Override
+	public MDCAdapter getMDCAdapter() {
+		return mdcAdapter;
+	}
+
+	@Override
+	public String getRequesteApiVersion() {
+		return REQUESTED_API_VERSION;
+	}
+
+	@Override
+	public void initialize() {
+		loggerFactory = new TinylogLoggerFactory();
+		markerFactory = new BasicMarkerFactory();
+		mdcAdapter = new TinylogMdcAdapter();
+	}
+}

--- a/slf4j-tinylog/src/main/resources/META-INF/services/org.slf4j.spi.SLF4JServiceProvider
+++ b/slf4j-tinylog/src/main/resources/META-INF/services/org.slf4j.spi.SLF4JServiceProvider
@@ -1,0 +1,1 @@
+org.tinylog.slf4j.TinylogSlf4jServiceProvider

--- a/slf4j-tinylog/src/test/java/org/tinylog/slf4j/TinylogSpiTest.java
+++ b/slf4j-tinylog/src/test/java/org/tinylog/slf4j/TinylogSpiTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Martin Winandy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.tinylog.slf4j;
+
+import org.junit.Test;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.IMarkerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.slf4j.MarkerFactory;
+import org.slf4j.helpers.BasicMarkerFactory;
+import org.slf4j.spi.MDCAdapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test Tinylog discovery via the service provider interface (SPI).
+ */
+public class TinylogSpiTest {
+
+	/** Find MDC adapter. */
+	@Test
+	public void findMdcAdapterViaSpi() {
+		final MDCAdapter adapter = MDC.getMDCAdapter();
+
+		assertThat(adapter).isExactlyInstanceOf(TinylogMdcAdapter.class);
+	}
+
+	/** Find logger factory. */
+	@Test
+	public void findLoggerFactoryViaSpi() {
+		final ILoggerFactory factory = LoggerFactory.getILoggerFactory();
+
+		assertThat(factory).isExactlyInstanceOf(TinylogLoggerFactory.class);
+	}
+
+	/** Find marker factory. */
+	@Test
+	public void findMarkerFactoryViaSpi() {
+		final IMarkerFactory factory = MarkerFactory.getIMarkerFactory();
+
+		assertThat(factory).isExactlyInstanceOf(BasicMarkerFactory.class);
+	}
+
+	/** Find logger. */
+	@Test
+	public void findLoggerViaSpi() {
+		final Logger logger = LoggerFactory.getLogger(getClass());
+
+		assertThat(logger).isExactlyInstanceOf(TinylogLogger.class);
+	}
+}


### PR DESCRIPTION
### Description

Linked issue: #119

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Code style follows the tinylog standard
- [x] All classes and methods have Javadoc
- [x] Changes are covered by JUnit tests including corner cases, errors, and exception handling
- [x] Maven build works including compiling, tests, and checks (`mvn verify`)
- [x] Changes are committed by a verified email address that is assigned to the GitHub account (https://github.com/settings/emails)

### Documentation

Additions or amendments for the [public documentation](https://github.com/pmwmedia/tinylog/wiki/Documentation):

```markdown
This patch allows to use Tinylog with SLF4J 1.8 and onwards, which requires locating SLF4J bindings via the service loader mechanism.
```

### Agreements

- [x] I agree that my changes will be published under the terms of the [Apache License 2.0](https://github.com/pmwmedia/tinylog/blob/v2.0/license.txt)
- [x] I agree that my GitHub user name will be published in the release notes

### Notes

- I didn't really see a good use-case for a unit test. It's really plain, devoid of any particular logic. Please feel free to give examples of testable properties if you think that's not the case.
- Also suspected in #119, using the SPI is **not** possible from SLF4J 1.7. Only SLF4J 1.8 and onwards contains the required interface.
- I'm not sure about the deprecation of the former method. At some point, we could likely remove the static binder classes `org.slf4j.impl.{StaticLoggerBinder,StaticMarkerBinder,StaticMDCBinder}` from Tinylog.
- It's me.... it's just been a while since #70 😄 