### PR TITLE
Support for building bleeding-edge Tinylog via JitPack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,4 @@
+jdk:
+  - openjdk9
+install:
+  - mvn clean install -DskipTests -Dcheckstyle.skip -Dspotbugs.skip -Dmaven.javadoc.skip -P release


### PR DESCRIPTION
By default, JitPack builds with Java 8, which is below the minimum required version for Tinylog (9). For more information on how to retrieve artifacts from JitPack, refer to https://jitpack.io/#tinylog-org/tinylog.

This allowed me to trivially test out my fix from a bug-fix branch in a consumer project. No need for deployment in the Maven local repository, or to invent new version numbers. This escapes "it works on my machine". An example dependency coordinate would be `com.github.f4lco.tinylog:slf4j-tinylog:4ce0fb5991d05642809f9257c37ac87197474734`.

There is only one minor catch: it may take JitPack longer to build and package the software than your configured socket read time out. It means the network request for the JAR might appear to hang until the Maven build on the JitPack remote machine completes. Either one increases the socket read timeout for Maven / Gradle, or one just tries a second time hoping that the build has completed by that time. This is of course only a one-time occurrence. Once a particular commit is built, JitPack reuses the same artifact for answering subsequent requests.

### Description

Linked issue: (none)

### Definition of Done

- [x] I read [contributing.md](./contributing.md)
- [x] There are no TODOs left in the code
- [x] ~~Code style follows the tinylog standard~~
- [x] ~~All classes and methods have Javadoc~~
- [x] ~~Changes are covered by JUnit tests including edge cases, errors, and exception handling~~
- [x] Maven build works including compiling, tests, and checks (`mvn verify`)
- [x] Changes are committed by a verified email address that is assigned to the GitHub account (https://github.com/settings/emails)

### Documentation

Additions or amendments for the [public documentation](https://github.com/pmwmedia/tinylog/wiki/Documentation):

```markdown
Users can retrieve bleeding edge Tinylog versions by using [JitPack](https://jitpack.io/#tinylog-org/tinylog) by specifying commit IDs as version numbers.
```

### Agreements

- [x] I agree that my changes will be published under the terms of the [Apache License 2.0](https://github.com/pmwmedia/tinylog/blob/v2.0/license.txt) (mandatory)
- [x] I agree that my GitHub user name will be published in the release notes (optional)
