### PR TITLE
Make benchmarks more comprehensive

### DIFF
--- a/benchmarks/src/main/java/org/tinylog/benchmarks/logging/AbstractBenchmark.java
+++ b/benchmarks/src/main/java/org/tinylog/benchmarks/logging/AbstractBenchmark.java
@@ -45,4 +45,13 @@ public abstract class AbstractBenchmark<T extends AbstractLifeCycle> {
 	 */
 	public abstract void output(T lifeCycle) throws Exception;
 
+	/**
+	 * Benchmarks a single logging statement. Used with {@code Mode.SampleTime}
+	 * to measure logging latency.
+	 *
+	 * @param lifeCycle Life cycle of the logging framework to benchmark
+	 * @throws Exception Failed to output log entries
+	 */
+	public abstract void outputSingle(T lifeCycle) throws Exception;
+
 }

--- a/benchmarks/src/main/java/org/tinylog/benchmarks/logging/jul_____/Jul_____Benchmark.java
+++ b/benchmarks/src/main/java/org/tinylog/benchmarks/logging/jul_____/Jul_____Benchmark.java
@@ -31,7 +31,7 @@ public class Jul_____Benchmark extends AbstractBenchmark<LifeCycle> {
 	}
 
 	@Benchmark
-	@BenchmarkMode(Mode.Throughput)
+	@BenchmarkMode({Mode.Throughput, Mode.SampleTime})
 	@Override
 	public void discard(final LifeCycle lifeCycle) {
 		lifeCycle.getLogger().log(java.util.logging.Level.CONFIG, "Hello {0}!", MAGIC_NUMBER);
@@ -47,6 +47,13 @@ public class Jul_____Benchmark extends AbstractBenchmark<LifeCycle> {
 		}
 
 		lifeCycle.waitForWriting();
+	}
+
+	@Benchmark
+	@BenchmarkMode(Mode.SampleTime)
+	@Override
+	public void outputSingle(final LifeCycle lifeCycle) throws IOException, InterruptedException {
+		lifeCycle.getLogger().log(java.util.logging.Level.INFO, "Hello {0}!", MAGIC_NUMBER);
 	}
 
 }

--- a/benchmarks/src/main/java/org/tinylog/benchmarks/logging/log4j1__/Log4j1__Benchmark.java
+++ b/benchmarks/src/main/java/org/tinylog/benchmarks/logging/log4j1__/Log4j1__Benchmark.java
@@ -31,7 +31,7 @@ public class Log4j1__Benchmark extends AbstractBenchmark<LifeCycle> {
 	}
 
 	@Benchmark
-	@BenchmarkMode(Mode.Throughput)
+	@BenchmarkMode({Mode.Throughput, Mode.SampleTime})
 	@Override
 	public void discard(final LifeCycle lifeCycle) {
 		lifeCycle.getLogger().debug("Hello " + MAGIC_NUMBER + "!");
@@ -47,6 +47,13 @@ public class Log4j1__Benchmark extends AbstractBenchmark<LifeCycle> {
 		}
 
 		lifeCycle.waitForWriting();
+	}
+
+	@Benchmark
+	@BenchmarkMode(Mode.SampleTime)
+	@Override
+	public void outputSingle(final LifeCycle lifeCycle) throws IOException, InterruptedException {
+		lifeCycle.getLogger().info("Hello " + MAGIC_NUMBER + "!");
 	}
 
 }

--- a/benchmarks/src/main/java/org/tinylog/benchmarks/logging/log4j2__/Log4j2__Benchmark.java
+++ b/benchmarks/src/main/java/org/tinylog/benchmarks/logging/log4j2__/Log4j2__Benchmark.java
@@ -31,7 +31,7 @@ public class Log4j2__Benchmark extends AbstractBenchmark<LifeCycle> {
 	}
 
 	@Benchmark
-	@BenchmarkMode(Mode.Throughput)
+	@BenchmarkMode({Mode.Throughput, Mode.SampleTime})
 	@Override
 	public void discard(final LifeCycle lifeCycle) {
 		lifeCycle.getLogger().debug("Hello {}!", MAGIC_NUMBER);
@@ -47,6 +47,13 @@ public class Log4j2__Benchmark extends AbstractBenchmark<LifeCycle> {
 		}
 
 		lifeCycle.waitForWriting();
+	}
+
+	@Benchmark
+	@BenchmarkMode(Mode.SampleTime)
+	@Override
+	public void outputSingle(final LifeCycle lifeCycle) throws IOException, InterruptedException {
+		lifeCycle.getLogger().info("Hello {}!", MAGIC_NUMBER);
 	}
 
 }

--- a/benchmarks/src/main/java/org/tinylog/benchmarks/logging/logback_/Logback_Benchmark.java
+++ b/benchmarks/src/main/java/org/tinylog/benchmarks/logging/logback_/Logback_Benchmark.java
@@ -32,7 +32,7 @@ public class Logback_Benchmark extends AbstractBenchmark<LifeCycle> {
 	}
 
 	@Benchmark
-	@BenchmarkMode(Mode.Throughput)
+	@BenchmarkMode({Mode.Throughput, Mode.SampleTime})
 	@Override
 	public void discard(final LifeCycle lifeCycle) {
 		lifeCycle.getLogger().debug("Hello {}!", MAGIC_NUMBER);
@@ -48,6 +48,13 @@ public class Logback_Benchmark extends AbstractBenchmark<LifeCycle> {
 		}
 
 		lifeCycle.waitForWriting();
+	}
+
+	@Benchmark
+	@BenchmarkMode(Mode.SampleTime)
+	@Override
+	public void outputSingle(final LifeCycle lifeCycle) throws IOException, InterruptedException {
+		lifeCycle.getLogger().info("Hello {}!", MAGIC_NUMBER);
 	}
 
 }

--- a/benchmarks/src/main/java/org/tinylog/benchmarks/logging/noop/NoOpBenchmark.java
+++ b/benchmarks/src/main/java/org/tinylog/benchmarks/logging/noop/NoOpBenchmark.java
@@ -30,7 +30,7 @@ public class NoOpBenchmark {
 	 * Benchmarks invoking an empty method.
 	 */
 	@Benchmark
-	@BenchmarkMode(Mode.Throughput)
+	@BenchmarkMode({Mode.Throughput, Mode.SampleTime})
 	public void emptyMethod() {
 	}
 

--- a/benchmarks/src/main/java/org/tinylog/benchmarks/logging/tinylog1/Tinylog1Benchmark.java
+++ b/benchmarks/src/main/java/org/tinylog/benchmarks/logging/tinylog1/Tinylog1Benchmark.java
@@ -31,7 +31,7 @@ public class Tinylog1Benchmark extends AbstractBenchmark<LifeCycle> {
 	}
 
 	@Benchmark
-	@BenchmarkMode(Mode.Throughput)
+	@BenchmarkMode({Mode.Throughput, Mode.SampleTime})
 	@Override
 	public void discard(final LifeCycle lifeCycle) {
 		Logger.debug("Hello {}!", MAGIC_NUMBER);
@@ -46,6 +46,13 @@ public class Tinylog1Benchmark extends AbstractBenchmark<LifeCycle> {
 		}
 
 		lifeCycle.waitForWriting();
+	}
+
+	@Benchmark
+	@BenchmarkMode(Mode.SampleTime)
+	@Override
+	public void outputSingle(final LifeCycle lifeCycle) throws IOException, InterruptedException {
+		Logger.info("Hello {}!", MAGIC_NUMBER);
 	}
 
 }

--- a/benchmarks/src/main/java/org/tinylog/benchmarks/logging/tinylog2/Tinylog2Benchmark.java
+++ b/benchmarks/src/main/java/org/tinylog/benchmarks/logging/tinylog2/Tinylog2Benchmark.java
@@ -31,7 +31,7 @@ public class Tinylog2Benchmark extends AbstractBenchmark<LifeCycle> {
 	}
 
 	@Benchmark
-	@BenchmarkMode(Mode.Throughput)
+	@BenchmarkMode({Mode.Throughput, Mode.SampleTime})
 	@Override
 	public void discard(final LifeCycle lifeCycle) {
 		Logger.debug("Hello {}!", MAGIC_NUMBER);
@@ -46,6 +46,13 @@ public class Tinylog2Benchmark extends AbstractBenchmark<LifeCycle> {
 		}
 
 		lifeCycle.waitForWriting();
+	}
+
+	@Benchmark
+	@BenchmarkMode(Mode.SampleTime)
+	@Override
+	public void outputSingle(final LifeCycle lifeCycle) throws IOException, InterruptedException {
+		Logger.info("Hello {}!", MAGIC_NUMBER);
 	}
 
 }


### PR DESCRIPTION
### Description

Linked issue: #202

### Definition of Done

- [x] I read [contributing.md](./contributing.md)
- [x] There are no TODOs left in the code
- [x] Code style follows the tinylog standard
- [x] All classes and methods have Javadoc --- Well, as is reasonable for benchmarks
- [x] Changes are covered by JUnit tests including edge cases, errors, and exception handling --- Not applicable here
- [x] Maven build works including compiling, tests, and checks (`mvn verify`)
- [x] Changes are committed by a verified email address that is assigned to the GitHub account (https://github.com/settings/emails)

I'm marking this as a draft actually because I'm not entirely sure about the validity of my approach. I'll explain below.

### Documentation

I'm not sure how you formatted the benchmark results on the [current page](https://tinylog.org/v2/benchmark/) so nicely.

### Agreements

- [x] I agree that my changes will be published under the terms of the [Apache License 2.0](https://github.com/pmwmedia/tinylog/blob/v2.0/license.txt)
- [x] I agree that my GitHub user name will be published in the release notes - Sure, if you find yourself making code changes based on these benchmarks

----------------------------------------------

I'm not very experienced with matters of benchmarking or high-performance, so I would appreciate if you could give some feedback on my approach. I have applied both what I know as well as what I've learned looking more into this subject.

I noticed that you used `waitForWriting` in the existing throughput benchmarks to wait for the log writer to finish. My logic in not doing so is that, to my knowledge, all the logging frameworks use a bounded buffer. So, while back-pressure can accumulate, the warmup iterations will fill up the initial buffer and all subsequent invocations will proceed in the same buffer-full environment. That suggests what we are really measuring here is the logging performance with a usually full buffer. For a latency sensitive situation, would it really be the case that the log buffer is frequently full?

Regarding the benchmark for discarded log entries, I was also wondering about simulating the effect of putting non-tinylog loggers in static-final fields. For other logging frameworks besides tinylog, it is common to place the logger in a `private static final` field. At the moment, `lifeCycle.getLogger()` for the other logging frameworks implies a field access (the method call will be inlined to the one field access). If final field values were used along with the experimental [`-XX:+TrustFinalNonStaticFields`](https://shipilev.net/jvm/anatomy-quarks/17-trust-nonstatic-final-fields/), that would be more akin to a `static final` field, for which the VM can potentially perform more optimizations.

I used SampleTime for the latency benchmarks. I assume what latency is trying to measure here is the time it takes the logging framework to return from a log call - that's another reason why I thought the benchmark should not use `waitForWriting` like the throughput one does.