### PR TITLE
Add support for logging with multiple tags

### DIFF
--- a/tinylog-api-kotlin/src/main/kotlin/org/tinylog/kotlin/Logger.kt
+++ b/tinylog-api-kotlin/src/main/kotlin/org/tinylog/kotlin/Logger.kt
@@ -38,7 +38,7 @@ object Logger {
 	private val MINIMUM_LEVEL_COVERS_ERROR = isCoveredByMinimumLevel(Level.ERROR)
 	// @formatter:on
 
-	private val instance = TaggedLogger(null)
+	private val instance = TaggedLogger(setOf(null))
 	private val loggers = ConcurrentHashMap<Set<String?>, TaggedLogger>()
 
 	init {

--- a/tinylog-api-kotlin/src/main/kotlin/org/tinylog/kotlin/Logger.kt
+++ b/tinylog-api-kotlin/src/main/kotlin/org/tinylog/kotlin/Logger.kt
@@ -39,7 +39,11 @@ object Logger {
 	// @formatter:on
 
 	private val instance = TaggedLogger(null)
-	private val loggers = ConcurrentHashMap<String, TaggedLogger>()
+	private val loggers = ConcurrentHashMap<Set<String?>, TaggedLogger>()
+
+	init {
+		loggers[setOf(null)] = instance
+	}
 
 	/**
 	 * Gets a tagged logger instance. Tags are case-sensitive.
@@ -49,17 +53,26 @@ object Logger {
 	 * @return Logger instance
 	 */
 	fun tag(tag: String?): TaggedLogger {
-		if (tag == null || tag.isEmpty()) {
-			return instance
+		return if (tag == null || tag.isEmpty()) {
+			instance
 		} else {
-			var logger = loggers[tag]
-			if (logger == null) {
-				logger = TaggedLogger(tag)
-				val existing = loggers.putIfAbsent(tag, logger)
-				return existing ?: logger
-			} else {
-				return logger
-			}
+			tags(tag)
+		}
+	}
+
+	/**
+	 * Gets a tagged logger instance that logs to multiple tags. Tags are case-sensitive.
+	 *
+	 * @param tags
+	 * 			Tags for the logger or nothing for an untagged logger. If specified, each tag should be unique
+	 * @return Logger instance
+	 */
+	fun tags(vararg tags: String?): TaggedLogger {
+		return if (tags == null || tags.isEmpty()) {
+			instance
+		} else {
+			val tagsSet = tags.map { if (it.isNullOrEmpty()) { null } else { it } }.toSet()
+			loggers.computeIfAbsent(tagsSet) { TaggedLogger(it) }
 		}
 	}
 

--- a/tinylog-api-kotlin/src/main/kotlin/org/tinylog/kotlin/TaggedLogger.kt
+++ b/tinylog-api-kotlin/src/main/kotlin/org/tinylog/kotlin/TaggedLogger.kt
@@ -28,8 +28,6 @@ import org.tinylog.provider.ProviderRegistry
  */
 class TaggedLogger internal constructor(private val tags: Set<String?>) {
 
-	constructor(tag: String?) : this(setOf(tag))
-
 	private val stackTraceDepth = 2
 
 	private val formatter = AdvancedMessageFormatter(Configuration.getLocale(), Configuration.isEscapingEnabled())

--- a/tinylog-api-kotlin/src/test/kotlin/org/tinylog/kotlin/LevelConfiguration.kt
+++ b/tinylog-api-kotlin/src/test/kotlin/org/tinylog/kotlin/LevelConfiguration.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021 Martin Winandy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.tinylog.kotlin
+
+import org.tinylog.Level
+
+/**
+ * This is intended to provide information about which log levels can be logged by a level. For example, TRACE is able to log all
+ * levels, whereas ERROR can log only at the ERROR level and OFF means none of the levels may be logged.
+ *
+ * @param level
+ * The actual log level that the information is for
+ * @param traceEnabled
+ * Determines if [[org.tinylog.Level#TRACE]] is enabled for the [[org.tinylog.Level#level]]
+ * @param debugEnabled
+ * Determines if [[org.tinylog.Level#DEBUG]] is enabled for the [[org.tinylog.Level#level]]
+ * @param infoEnabled
+ * Determines if [[org.tinylog.Level#INFO]] is enabled for the [[org.tinylog.Level#level]]
+ * @param warnEnabled
+ * Determines if [[org.tinylog.Level#WARN]] is enabled for the [[org.tinylog.Level#level]]
+ * @param errorEnabled
+ * Determines if [[org.tinylog.Level#ERROR]] is enabled for the [[org.tinylog.Level#level]]
+ */
+class LevelConfiguration(val level: Level, val traceEnabled: Boolean, val debugEnabled: Boolean,
+                         val infoEnabled: Boolean, val warnEnabled: Boolean, val errorEnabled: Boolean) {
+
+    override fun toString(): String {
+        return level.toString()
+    }
+
+    companion object {
+
+        /**
+         * List of all severity levels each other levels are "enabled" by them. The other level is enabled if it can be logged. This usually
+         * means that the other level is also of a higher severity level.
+         */
+        @JvmStatic
+        val AVAILABLE_LEVELS by lazy {
+            listOf(
+                LevelConfiguration(
+                    Level.TRACE,
+                    traceEnabled = true,
+                    debugEnabled = true,
+                    infoEnabled = true,
+                    warnEnabled = true,
+                    errorEnabled = true
+                ),
+                LevelConfiguration(
+                    Level.DEBUG,
+                    traceEnabled = false,
+                    debugEnabled = true,
+                    infoEnabled = true,
+                    warnEnabled = true,
+                    errorEnabled = true
+                ),
+                LevelConfiguration(
+                    Level.INFO,
+                    traceEnabled = false,
+                    debugEnabled = false,
+                    infoEnabled = true,
+                    warnEnabled = true,
+                    errorEnabled = true
+                ),
+                LevelConfiguration(
+                    Level.WARN,
+                    traceEnabled = false,
+                    debugEnabled = false,
+                    infoEnabled = false,
+                    warnEnabled = true,
+                    errorEnabled = true
+                ),
+                LevelConfiguration(
+                    Level.ERROR,
+                    traceEnabled = false,
+                    debugEnabled = false,
+                    infoEnabled = false,
+                    warnEnabled = false,
+                    errorEnabled = true
+                ),
+                LevelConfiguration(
+                    Level.OFF,
+                    traceEnabled = false,
+                    debugEnabled = false,
+                    infoEnabled = false,
+                    warnEnabled = false,
+                    errorEnabled = false
+                )
+            )
+        }
+    }
+}

--- a/tinylog-api-kotlin/src/test/kotlin/org/tinylog/kotlin/TaggedLoggerTest.kt
+++ b/tinylog-api-kotlin/src/test/kotlin/org/tinylog/kotlin/TaggedLoggerTest.kt
@@ -96,7 +96,7 @@ class TaggedLoggerTest(private val tag1Configuration: LevelConfiguration, privat
 		every { loggingProvider.isEnabled(any(), tag1, Level.ERROR) } returns tag1Configuration.errorEnabled
 
 		logger = if (tag2Configuration == null) {
-			TaggedLogger(tag1)
+			TaggedLogger(setOf(tag1))
 		} else {
 			every { loggingProvider.getMinimumLevel(tag2) } returns tag2Configuration.level
 

--- a/tinylog-api-scala/src/main/scala/org/tinylog/scala/TaggedLogger.scala
+++ b/tinylog-api-scala/src/main/scala/org/tinylog/scala/TaggedLogger.scala
@@ -16,15 +16,17 @@ package org.tinylog.scala
 import scala.language.experimental.macros
 
 /**
-	* Logger for issuing tagged log entries. Tagged loggers can be received by calling [[org.tinylog.scala.Logger.tag]].
+	* Logger for issuing tagged log entries. Tagged loggers can be received by calling [[org.tinylog.scala.Logger.tag]] or
+	* [[org.tinylog.scala.Logger.tags]].
 	*
-	* @param tag
-	* Case-sensitive tag for logger instance
+	* @param tags
+	* Case-sensitive tags for logger instance
 	* @see org.tinylog.scala.Logger.tag
+	* @see org.tinylog.scala.Logger.tags
 	*/
-final class TaggedLogger private[scala] (private val tag: String) {
+final class TaggedLogger private[scala] (private val tags: Set[String]) {
 
-	private[scala] final val logger = org.tinylog.Logger.tag(tag)
+	private[scala] final val logger = org.tinylog.Logger.tags(tags.toSeq: _*)
 
 	/**
 		* Checks whether log entries at [[https://tinylog.org/v2/javadoc/org/tinylog/Level.html#TRACE TRACE]] will be output.

--- a/tinylog-api-scala/src/test/scala/org/tinylog/scala/LevelConfiguration.scala
+++ b/tinylog-api-scala/src/test/scala/org/tinylog/scala/LevelConfiguration.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 Martin Winandy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.tinylog.scala
+
+import org.tinylog.Level
+
+/**
+  * This is intended to provide information about which log levels can be logged by a level. For example, TRACE is able to log all
+  * levels, whereas ERROR can log only at the ERROR level and OFF means none of the levels may be logged.
+  *
+  * @param level
+  * The actual log level that the information is for
+  * @param traceEnabled
+  * Determines if [[org.tinylog.Level#TRACE]] is enabled for the [[org.tinylog.Level#level]]
+  * @param debugEnabled
+  * Determines if [[org.tinylog.Level#DEBUG]] is enabled for the [[org.tinylog.Level#level]]
+  * @param infoEnabled
+  * Determines if [[org.tinylog.Level#INFO]] is enabled for the [[org.tinylog.Level#level]]
+  * @param warnEnabled
+  * Determines if [[org.tinylog.Level#WARN]] is enabled for the [[org.tinylog.Level#level]]
+  * @param errorEnabled
+  * Determines if [[org.tinylog.Level#ERROR]] is enabled for the [[org.tinylog.Level#level]]
+  */
+final class LevelConfiguration(val level: Level, val traceEnabled: Boolean, val debugEnabled: Boolean,
+                               val infoEnabled: Boolean, val warnEnabled: Boolean, val errorEnabled: Boolean) {
+  override def toString: String = { level.toString() }
+}
+
+object LevelConfiguration {
+  /**
+    * List of all severity levels each other levels are "enabled" by them. The other level is enabled if it can be logged. This usually
+    * means that the other level is also of a higher severity level.
+    */
+  val AVAILABLE_LEVELS = Array(
+    new LevelConfiguration(
+      level = Level.TRACE,
+      traceEnabled = true,
+      debugEnabled = true,
+      infoEnabled = true,
+      warnEnabled = true,
+      errorEnabled = true
+    ),
+    new LevelConfiguration(
+      level = Level.DEBUG,
+      traceEnabled = false,
+      debugEnabled = true,
+      infoEnabled = true,
+      warnEnabled = true,
+      errorEnabled = true
+    ),
+    new LevelConfiguration(
+      level = Level.INFO,
+      traceEnabled = false,
+      debugEnabled = false,
+      infoEnabled = true,
+      warnEnabled = true,
+      errorEnabled = true
+    ),
+    new LevelConfiguration(
+      level = Level.WARN,
+      traceEnabled = false,
+      debugEnabled = false,
+      infoEnabled = false,
+      warnEnabled = true,
+      errorEnabled = true
+    ),
+    new LevelConfiguration(
+      level = Level.ERROR,
+      traceEnabled = false,
+      debugEnabled = false,
+      infoEnabled = false,
+      warnEnabled = false,
+      errorEnabled = true
+    ),
+    new LevelConfiguration(
+      level = Level.OFF,
+      traceEnabled = false,
+      debugEnabled = false,
+      infoEnabled = false,
+      warnEnabled = false,
+      errorEnabled = false
+    )
+  )
+}

--- a/tinylog-api-scala/src/test/scala/org/tinylog/scala/LoggerTest.scala
+++ b/tinylog-api-scala/src/test/scala/org/tinylog/scala/LoggerTest.scala
@@ -35,21 +35,11 @@ import org.tinylog.{Level, Supplier}
 	* Tests for logging methods of [[org.tinylog.scala.Logger]].
 	*
 	* @param level
-	* Actual severity level under test
-	* @param traceEnabled
-	* Determines if [[org.tinylog.Level#TRACE]] is enabled
-	* @param debugEnabled
-	* Determines if [[org.tinylog.Level#DEBUG]] is enabled
-	* @param infoEnabled
-	* Determines if [[org.tinylog.Level#INFO]] is enabled
-	* @param warnEnabled
-	* Determines if [[org.tinylog.Level#WARN]] is enabled
-	* @param errorEnabled
-	* Determines if [[org.tinylog.Level#ERROR]] is enabled
+	* The level and related information about it under test
 	*/
 @RunWith(classOf[Parameterized])
 @PrepareForTest(Array(classOf[org.tinylog.Logger]))
-final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEnabled: Boolean, var infoEnabled: Boolean, var warnEnabled: Boolean, var errorEnabled: Boolean) {
+final class LoggerTest(var level: LevelConfiguration) {
 
 	/**
 		* Activates PowerMock (alternative to [[org.powermock.modules.junit4.PowerMockRunner]]).
@@ -81,7 +71,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		* Verifies evaluating whether [[org.tinylog.Level#TRACE]] is enabled.
 		*/
 	@Test def isTraceEnabled(): Unit = {
-		assertThat(Logger.isTraceEnabled).isEqualTo(traceEnabled)
+		assertThat(Logger.isTraceEnabled).isEqualTo(level.traceEnabled)
 	}
 
 	/**
@@ -90,7 +80,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def traceNumber(): Unit = {
 		Logger.trace(42.asInstanceOf[Any])
 
-		if (traceEnabled) verify(loggingProvider).log(2, null, Level.TRACE, null, null, 42, null.asInstanceOf[Array[AnyRef]])
+		if (level.traceEnabled) verify(loggingProvider).log(2, null, Level.TRACE, null, null, 42, null.asInstanceOf[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -100,7 +90,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def traceStaticString(): Unit = {
 		Logger.trace("Hello World!")
 
-		if (traceEnabled) verify(loggingProvider).log(2, null, Level.TRACE, null, null, "Hello World!", null.asInstanceOf[Array[AnyRef]])
+		if (level.traceEnabled) verify(loggingProvider).log(2, null, Level.TRACE, null, null, "Hello World!", null.asInstanceOf[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -111,7 +101,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val name = "Mister"
 		Logger.trace(s"Hello $name!")
 
-		if (traceEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.TRACE), isNull[Throwable], isNull[MessageFormatter], argThat(supplies("Hello Mister!")), isNull[Array[AnyRef]])
+		if (level.traceEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.TRACE), isNull[Throwable], isNull[MessageFormatter], argThat(supplies("Hello Mister!")), isNull[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -121,7 +111,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def traceLazyMessage(): Unit = {
 		Logger.trace(() => "Hello World!")
 
-		if (traceEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.TRACE), isNull[Throwable], isNull[MessageFormatter], argThat(supplies("Hello World!")), isNull[Array[AnyRef]])
+		if (level.traceEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.TRACE), isNull[Throwable], isNull[MessageFormatter], argThat(supplies("Hello World!")), isNull[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -131,7 +121,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def traceMessageAndArguments(): Unit = {
 		Logger.trace("Hello {}!", "World")
 
-		if (traceEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.TRACE), isNull[Throwable], any(classOf[MessageFormatter]), eqTo("Hello {}!"), eqTo("World"))
+		if (level.traceEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.TRACE), isNull[Throwable], any(classOf[MessageFormatter]), eqTo("Hello {}!"), eqTo("World"))
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -141,7 +131,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def traceMessageAndLazyArguments(): Unit = {
 		Logger.trace("The number is {}", () => 42)
 
-		if (traceEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.TRACE), isNull[Throwable], any(classOf[MessageFormatter]), eqTo("The number is {}"), argThat(supplies(42)))
+		if (level.traceEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.TRACE), isNull[Throwable], any(classOf[MessageFormatter]), eqTo("The number is {}"), argThat(supplies(42)))
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -152,7 +142,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.trace(exception)
 
-		if (traceEnabled) verify(loggingProvider).log(2, null, Level.TRACE, exception, null, null, null.asInstanceOf[Array[AnyRef]])
+		if (level.traceEnabled) verify(loggingProvider).log(2, null, Level.TRACE, exception, null, null, null.asInstanceOf[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -163,7 +153,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.trace(exception, "Hello World!")
 
-		if (traceEnabled) verify(loggingProvider).log(2, null, Level.TRACE, exception, null, "Hello World!", null.asInstanceOf[Array[AnyRef]])
+		if (level.traceEnabled) verify(loggingProvider).log(2, null, Level.TRACE, exception, null, "Hello World!", null.asInstanceOf[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -175,7 +165,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val name = "Mister"
 		Logger.trace(exception, s"Hello $name!")
 
-		if (traceEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.TRACE), eqTo(exception), isNull[MessageFormatter], argThat(supplies("Hello Mister!")), isNull[Array[AnyRef]])
+		if (level.traceEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.TRACE), eqTo(exception), isNull[MessageFormatter], argThat(supplies("Hello Mister!")), isNull[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -186,7 +176,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.trace(exception, () => "Hello World!")
 
-		if (traceEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.TRACE), eqTo(exception), isNull[MessageFormatter], argThat(supplies("Hello World!")), isNull[Array[AnyRef]])
+		if (level.traceEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.TRACE), eqTo(exception), isNull[MessageFormatter], argThat(supplies("Hello World!")), isNull[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -197,7 +187,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.trace(exception, "Hello {}!", "World")
 
-		if (traceEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.TRACE), same(exception), any(classOf[MessageFormatter]), eqTo("Hello {}!"), eqTo("World"))
+		if (level.traceEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.TRACE), same(exception), any(classOf[MessageFormatter]), eqTo("Hello {}!"), eqTo("World"))
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -208,7 +198,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.trace(exception, "The number is {}", () => 42)
 
-		if (traceEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.TRACE), eqTo(exception), any(classOf[MessageFormatter]), eqTo("The number is {}"), argThat(supplies(42)))
+		if (level.traceEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.TRACE), eqTo(exception), any(classOf[MessageFormatter]), eqTo("The number is {}"), argThat(supplies(42)))
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -216,7 +206,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		* Verifies evaluating whether [[org.tinylog.Level#DEBUG]] is enabled.
 		*/
 	@Test def isDebugEnabled(): Unit = {
-		assertThat(Logger.isDebugEnabled).isEqualTo(debugEnabled)
+		assertThat(Logger.isDebugEnabled).isEqualTo(level.debugEnabled)
 	}
 
 	/**
@@ -225,7 +215,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def debugNumber(): Unit = {
 		Logger.debug(42.asInstanceOf[Any])
 
-		if (debugEnabled) verify(loggingProvider).log(2, null, Level.DEBUG, null, null, 42, null.asInstanceOf[Array[AnyRef]])
+		if (level.debugEnabled) verify(loggingProvider).log(2, null, Level.DEBUG, null, null, 42, null.asInstanceOf[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -235,7 +225,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def debugStaticString(): Unit = {
 		Logger.debug("Hello World!")
 
-		if (debugEnabled) verify(loggingProvider).log(2, null, Level.DEBUG, null, null, "Hello World!", null.asInstanceOf[Array[AnyRef]])
+		if (level.debugEnabled) verify(loggingProvider).log(2, null, Level.DEBUG, null, null, "Hello World!", null.asInstanceOf[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -246,7 +236,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val name = "Mister"
 		Logger.debug(s"Hello $name!")
 
-		if (debugEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.DEBUG), isNull[Throwable], isNull[MessageFormatter], argThat(supplies("Hello Mister!")), isNull[Array[AnyRef]])
+		if (level.debugEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.DEBUG), isNull[Throwable], isNull[MessageFormatter], argThat(supplies("Hello Mister!")), isNull[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -256,7 +246,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def debugLazyMessage(): Unit = {
 		Logger.debug(() => "Hello World!")
 
-		if (debugEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.DEBUG), isNull[Throwable], isNull[MessageFormatter], argThat(supplies("Hello World!")), isNull[Array[AnyRef]])
+		if (level.debugEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.DEBUG), isNull[Throwable], isNull[MessageFormatter], argThat(supplies("Hello World!")), isNull[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -266,7 +256,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def debugMessageAndArguments(): Unit = {
 		Logger.debug("Hello {}!", "World")
 
-		if (debugEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.DEBUG), isNull[Throwable], any(classOf[MessageFormatter]), eqTo("Hello {}!"), eqTo("World"))
+		if (level.debugEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.DEBUG), isNull[Throwable], any(classOf[MessageFormatter]), eqTo("Hello {}!"), eqTo("World"))
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -276,7 +266,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def debugMessageAndLazyArguments(): Unit = {
 		Logger.debug("The number is {}", () => 42)
 
-		if (debugEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.DEBUG), isNull[Throwable], any(classOf[MessageFormatter]), eqTo("The number is {}"), argThat(supplies(42)))
+		if (level.debugEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.DEBUG), isNull[Throwable], any(classOf[MessageFormatter]), eqTo("The number is {}"), argThat(supplies(42)))
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -287,7 +277,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.debug(exception)
 
-		if (debugEnabled) verify(loggingProvider).log(2, null, Level.DEBUG, exception, null, null, null.asInstanceOf[Array[AnyRef]])
+		if (level.debugEnabled) verify(loggingProvider).log(2, null, Level.DEBUG, exception, null, null, null.asInstanceOf[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -298,7 +288,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.debug(exception, "Hello World!")
 
-		if (debugEnabled) verify(loggingProvider).log(2, null, Level.DEBUG, exception, null, "Hello World!", null.asInstanceOf[Array[AnyRef]])
+		if (level.debugEnabled) verify(loggingProvider).log(2, null, Level.DEBUG, exception, null, "Hello World!", null.asInstanceOf[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -310,7 +300,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val name = "Mister"
 		Logger.debug(exception, s"Hello $name!")
 
-		if (debugEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.DEBUG), eqTo(exception), isNull[MessageFormatter], argThat(supplies("Hello Mister!")), isNull[Array[AnyRef]])
+		if (level.debugEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.DEBUG), eqTo(exception), isNull[MessageFormatter], argThat(supplies("Hello Mister!")), isNull[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -321,7 +311,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.debug(exception, () => "Hello World!")
 
-		if (debugEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.DEBUG), eqTo(exception), isNull[MessageFormatter], argThat(supplies("Hello World!")), isNull[Array[AnyRef]])
+		if (level.debugEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.DEBUG), eqTo(exception), isNull[MessageFormatter], argThat(supplies("Hello World!")), isNull[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -332,7 +322,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.debug(exception, "Hello {}!", "World")
 
-		if (debugEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.DEBUG), same(exception), any(classOf[MessageFormatter]), eqTo("Hello {}!"), eqTo("World"))
+		if (level.debugEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.DEBUG), same(exception), any(classOf[MessageFormatter]), eqTo("Hello {}!"), eqTo("World"))
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -343,7 +333,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.debug(exception, "The number is {}", () => 42)
 
-		if (debugEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.DEBUG), eqTo(exception), any(classOf[MessageFormatter]), eqTo("The number is {}"), argThat(supplies(42)))
+		if (level.debugEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.DEBUG), eqTo(exception), any(classOf[MessageFormatter]), eqTo("The number is {}"), argThat(supplies(42)))
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -351,7 +341,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		* Verifies evaluating whether [[org.tinylog.Level#INFO]] is enabled.
 		*/
 	@Test def isInfoEnabled(): Unit = {
-		assertThat(Logger.isInfoEnabled).isEqualTo(infoEnabled)
+		assertThat(Logger.isInfoEnabled).isEqualTo(level.infoEnabled)
 	}
 
 	/**
@@ -360,7 +350,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def infoNumber(): Unit = {
 		Logger.info(42.asInstanceOf[Any])
 
-		if (infoEnabled) verify(loggingProvider).log(2, null, Level.INFO, null, null, 42, null.asInstanceOf[Array[AnyRef]])
+		if (level.infoEnabled) verify(loggingProvider).log(2, null, Level.INFO, null, null, 42, null.asInstanceOf[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -370,7 +360,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def infoStaticString(): Unit = {
 		Logger.info("Hello World!")
 
-		if (infoEnabled) verify(loggingProvider).log(2, null, Level.INFO, null, null, "Hello World!", null.asInstanceOf[Array[AnyRef]])
+		if (level.infoEnabled) verify(loggingProvider).log(2, null, Level.INFO, null, null, "Hello World!", null.asInstanceOf[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -381,7 +371,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val name = "Mister"
 		Logger.info(s"Hello $name!")
 
-		if (infoEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.INFO), isNull[Throwable], isNull[MessageFormatter], argThat(supplies("Hello Mister!")), isNull[Array[AnyRef]])
+		if (level.infoEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.INFO), isNull[Throwable], isNull[MessageFormatter], argThat(supplies("Hello Mister!")), isNull[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -391,7 +381,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def infoLazyMessage(): Unit = {
 		Logger.info(() => "Hello World!")
 
-		if (infoEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.INFO), isNull[Throwable], isNull[MessageFormatter], argThat(supplies("Hello World!")), isNull[Array[AnyRef]])
+		if (level.infoEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.INFO), isNull[Throwable], isNull[MessageFormatter], argThat(supplies("Hello World!")), isNull[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -401,7 +391,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def infoMessageAndArguments(): Unit = {
 		Logger.info("Hello {}!", "World")
 
-		if (infoEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.INFO), isNull[Throwable], any(classOf[MessageFormatter]), eqTo("Hello {}!"), eqTo("World"))
+		if (level.infoEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.INFO), isNull[Throwable], any(classOf[MessageFormatter]), eqTo("Hello {}!"), eqTo("World"))
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -411,7 +401,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def infoMessageAndLazyArguments(): Unit = {
 		Logger.info("The number is {}", () => 42)
 
-		if (infoEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.INFO), isNull[Throwable], any(classOf[MessageFormatter]), eqTo("The number is {}"), argThat(supplies(42)))
+		if (level.infoEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.INFO), isNull[Throwable], any(classOf[MessageFormatter]), eqTo("The number is {}"), argThat(supplies(42)))
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -422,7 +412,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.info(exception)
 
-		if (infoEnabled) verify(loggingProvider).log(2, null, Level.INFO, exception, null, null, null.asInstanceOf[Array[AnyRef]])
+		if (level.infoEnabled) verify(loggingProvider).log(2, null, Level.INFO, exception, null, null, null.asInstanceOf[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -433,7 +423,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.info(exception, "Hello World!")
 
-		if (infoEnabled) verify(loggingProvider).log(2, null, Level.INFO, exception, null, "Hello World!", null.asInstanceOf[Array[AnyRef]])
+		if (level.infoEnabled) verify(loggingProvider).log(2, null, Level.INFO, exception, null, "Hello World!", null.asInstanceOf[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -445,7 +435,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val name = "Mister"
 		Logger.info(exception, s"Hello $name!")
 
-		if (infoEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.INFO), eqTo(exception), isNull[MessageFormatter], argThat(supplies("Hello Mister!")), isNull[Array[AnyRef]])
+		if (level.infoEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.INFO), eqTo(exception), isNull[MessageFormatter], argThat(supplies("Hello Mister!")), isNull[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -456,7 +446,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.info(exception, () => "Hello World!")
 
-		if (infoEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.INFO), eqTo(exception), isNull[MessageFormatter], argThat(supplies("Hello World!")), isNull[Array[AnyRef]])
+		if (level.infoEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.INFO), eqTo(exception), isNull[MessageFormatter], argThat(supplies("Hello World!")), isNull[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -467,7 +457,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.info(exception, "Hello {}!", "World")
 
-		if (infoEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.INFO), same(exception), any(classOf[MessageFormatter]), eqTo("Hello {}!"), eqTo("World"))
+		if (level.infoEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.INFO), same(exception), any(classOf[MessageFormatter]), eqTo("Hello {}!"), eqTo("World"))
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -478,7 +468,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.info(exception, "The number is {}", () => 42)
 
-		if (infoEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.INFO), eqTo(exception), any(classOf[MessageFormatter]), eqTo("The number is {}"), argThat(supplies(42)))
+		if (level.infoEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.INFO), eqTo(exception), any(classOf[MessageFormatter]), eqTo("The number is {}"), argThat(supplies(42)))
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -486,7 +476,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		* Verifies evaluating whether [[org.tinylog.Level#WARN]] is enabled.
 		*/
 	@Test def isWarnEnabled(): Unit = {
-		assertThat(Logger.isWarnEnabled).isEqualTo(warnEnabled)
+		assertThat(Logger.isWarnEnabled).isEqualTo(level.warnEnabled)
 	}
 
 	/**
@@ -495,7 +485,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def warnNumber(): Unit = {
 		Logger.warn(42.asInstanceOf[Any])
 
-		if (warnEnabled) verify(loggingProvider).log(2, null, Level.WARN, null, null, 42, null.asInstanceOf[Array[AnyRef]])
+		if (level.warnEnabled) verify(loggingProvider).log(2, null, Level.WARN, null, null, 42, null.asInstanceOf[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -505,7 +495,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def warnStaticString(): Unit = {
 		Logger.warn("Hello World!")
 
-		if (warnEnabled) verify(loggingProvider).log(2, null, Level.WARN, null, null, "Hello World!", null.asInstanceOf[Array[AnyRef]])
+		if (level.warnEnabled) verify(loggingProvider).log(2, null, Level.WARN, null, null, "Hello World!", null.asInstanceOf[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -516,7 +506,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val name = "Mister"
 		Logger.warn(s"Hello $name!")
 
-		if (warnEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.WARN), isNull[Throwable], isNull[MessageFormatter], argThat(supplies("Hello Mister!")), isNull[Array[AnyRef]])
+		if (level.warnEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.WARN), isNull[Throwable], isNull[MessageFormatter], argThat(supplies("Hello Mister!")), isNull[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -526,7 +516,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def warnLazyMessage(): Unit = {
 		Logger.warn(() => "Hello World!")
 
-		if (warnEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.WARN), isNull[Throwable], isNull[MessageFormatter], argThat(supplies("Hello World!")), isNull[Array[AnyRef]])
+		if (level.warnEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.WARN), isNull[Throwable], isNull[MessageFormatter], argThat(supplies("Hello World!")), isNull[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -536,7 +526,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def warnMessageAndArguments(): Unit = {
 		Logger.warn("Hello {}!", "World")
 
-		if (warnEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.WARN), isNull[Throwable], any(classOf[MessageFormatter]), eqTo("Hello {}!"), eqTo("World"))
+		if (level.warnEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.WARN), isNull[Throwable], any(classOf[MessageFormatter]), eqTo("Hello {}!"), eqTo("World"))
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -546,7 +536,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def warnMessageAndLazyArguments(): Unit = {
 		Logger.warn("The number is {}", () => 42)
 
-		if (warnEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.WARN), isNull[Throwable], any(classOf[MessageFormatter]), eqTo("The number is {}"), argThat(supplies(42)))
+		if (level.warnEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.WARN), isNull[Throwable], any(classOf[MessageFormatter]), eqTo("The number is {}"), argThat(supplies(42)))
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -557,7 +547,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.warn(exception)
 
-		if (warnEnabled) verify(loggingProvider).log(2, null, Level.WARN, exception, null, null, null.asInstanceOf[Array[AnyRef]])
+		if (level.warnEnabled) verify(loggingProvider).log(2, null, Level.WARN, exception, null, null, null.asInstanceOf[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -568,7 +558,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.warn(exception, "Hello World!")
 
-		if (warnEnabled) verify(loggingProvider).log(2, null, Level.WARN, exception, null, "Hello World!", null.asInstanceOf[Array[AnyRef]])
+		if (level.warnEnabled) verify(loggingProvider).log(2, null, Level.WARN, exception, null, "Hello World!", null.asInstanceOf[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -580,7 +570,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val name = "Mister"
 		Logger.warn(exception, s"Hello $name!")
 
-		if (warnEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.WARN), eqTo(exception), isNull[MessageFormatter], argThat(supplies("Hello Mister!")), isNull[Array[AnyRef]])
+		if (level.warnEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.WARN), eqTo(exception), isNull[MessageFormatter], argThat(supplies("Hello Mister!")), isNull[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -591,7 +581,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.warn(exception, () => "Hello World!")
 
-		if (warnEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.WARN), eqTo(exception), isNull[MessageFormatter], argThat(supplies("Hello World!")), isNull[Array[AnyRef]])
+		if (level.warnEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.WARN), eqTo(exception), isNull[MessageFormatter], argThat(supplies("Hello World!")), isNull[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -602,7 +592,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.warn(exception, "Hello {}!", "World")
 
-		if (warnEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.WARN), same(exception), any(classOf[MessageFormatter]), eqTo("Hello {}!"), eqTo("World"))
+		if (level.warnEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.WARN), same(exception), any(classOf[MessageFormatter]), eqTo("Hello {}!"), eqTo("World"))
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -613,7 +603,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.warn(exception, "The number is {}", () => 42)
 
-		if (warnEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.WARN), eqTo(exception), any(classOf[MessageFormatter]), eqTo("The number is {}"), argThat(supplies(42)))
+		if (level.warnEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.WARN), eqTo(exception), any(classOf[MessageFormatter]), eqTo("The number is {}"), argThat(supplies(42)))
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -621,7 +611,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		* Verifies evaluating whether [[org.tinylog.Level#ERROR]] is enabled.
 		*/
 	@Test def isErrorEnabled(): Unit = {
-		assertThat(Logger.isErrorEnabled).isEqualTo(errorEnabled)
+		assertThat(Logger.isErrorEnabled).isEqualTo(level.errorEnabled)
 	}
 
 	/**
@@ -630,7 +620,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def errorNumber(): Unit = {
 		Logger.error(42.asInstanceOf[Any])
 
-		if (errorEnabled) verify(loggingProvider).log(2, null, Level.ERROR, null, null, 42, null.asInstanceOf[Array[AnyRef]])
+		if (level.errorEnabled) verify(loggingProvider).log(2, null, Level.ERROR, null, null, 42, null.asInstanceOf[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -640,7 +630,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def errorStaticString(): Unit = {
 		Logger.error("Hello World!")
 
-		if (errorEnabled) verify(loggingProvider).log(2, null, Level.ERROR, null, null, "Hello World!", null.asInstanceOf[Array[AnyRef]])
+		if (level.errorEnabled) verify(loggingProvider).log(2, null, Level.ERROR, null, null, "Hello World!", null.asInstanceOf[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -651,7 +641,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val name = "Mister"
 		Logger.error(s"Hello $name!")
 
-		if (errorEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.ERROR), isNull[Throwable], isNull[MessageFormatter], argThat(supplies("Hello Mister!")), isNull[Array[AnyRef]])
+		if (level.errorEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.ERROR), isNull[Throwable], isNull[MessageFormatter], argThat(supplies("Hello Mister!")), isNull[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -661,7 +651,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def errorLazyMessage(): Unit = {
 		Logger.error(() => "Hello World!")
 
-		if (errorEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.ERROR), isNull[Throwable], isNull[MessageFormatter], argThat(supplies("Hello World!")), isNull[Array[AnyRef]])
+		if (level.errorEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.ERROR), isNull[Throwable], isNull[MessageFormatter], argThat(supplies("Hello World!")), isNull[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -671,7 +661,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def errorMessageAndArguments(): Unit = {
 		Logger.error("Hello {}!", "World")
 
-		if (errorEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.ERROR), isNull[Throwable], any(classOf[MessageFormatter]), eqTo("Hello {}!"), eqTo("World"))
+		if (level.errorEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.ERROR), isNull[Throwable], any(classOf[MessageFormatter]), eqTo("Hello {}!"), eqTo("World"))
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -681,7 +671,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	@Test def errorMessageAndLazyArguments(): Unit = {
 		Logger.error("The number is {}", () => 42)
 
-		if (errorEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.ERROR), isNull[Throwable], any(classOf[MessageFormatter]), eqTo("The number is {}"), argThat(supplies(42)))
+		if (level.errorEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.ERROR), isNull[Throwable], any(classOf[MessageFormatter]), eqTo("The number is {}"), argThat(supplies(42)))
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -692,7 +682,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.error(exception)
 
-		if (errorEnabled) verify(loggingProvider).log(2, null, Level.ERROR, exception, null, null, null.asInstanceOf[Array[AnyRef]])
+		if (level.errorEnabled) verify(loggingProvider).log(2, null, Level.ERROR, exception, null, null, null.asInstanceOf[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -703,7 +693,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.error(exception, "Hello World!")
 
-		if (errorEnabled) verify(loggingProvider).log(2, null, Level.ERROR, exception, null, "Hello World!", null.asInstanceOf[Array[AnyRef]])
+		if (level.errorEnabled) verify(loggingProvider).log(2, null, Level.ERROR, exception, null, "Hello World!", null.asInstanceOf[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -715,7 +705,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val name = "Mister"
 		Logger.error(exception, s"Hello $name!")
 
-		if (errorEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.ERROR), eqTo(exception), isNull[MessageFormatter], argThat(supplies("Hello Mister!")), isNull[Array[AnyRef]])
+		if (level.errorEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.ERROR), eqTo(exception), isNull[MessageFormatter], argThat(supplies("Hello Mister!")), isNull[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -726,7 +716,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.error(exception, () => "Hello World!")
 
-		if (errorEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.ERROR), eqTo(exception), isNull[MessageFormatter], argThat(supplies("Hello World!")), isNull[Array[AnyRef]])
+		if (level.errorEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.ERROR), eqTo(exception), isNull[MessageFormatter], argThat(supplies("Hello World!")), isNull[Array[AnyRef]])
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -737,7 +727,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.error(exception, "Hello {}!", "World")
 
-		if (errorEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.ERROR), same(exception), any(classOf[MessageFormatter]), eqTo("Hello {}!"), eqTo("World"))
+		if (level.errorEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.ERROR), same(exception), any(classOf[MessageFormatter]), eqTo("Hello {}!"), eqTo("World"))
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -748,7 +738,7 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 		val exception = new NullPointerException
 		Logger.error(exception, "The number is {}", () => 42)
 
-		if (errorEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.ERROR), eqTo(exception), any(classOf[MessageFormatter]), eqTo("The number is {}"), argThat(supplies(42)))
+		if (level.errorEnabled) verify(loggingProvider).log(eqTo(2), isNull[String], eqTo(Level.ERROR), eqTo(exception), any(classOf[MessageFormatter]), eqTo("The number is {}"), argThat(supplies(42)))
 		else verify(loggingProvider, never).log(anyInt, anyString, any, any, any, any, any[Array[AnyRef]])
 	}
 
@@ -760,19 +750,19 @@ final class LoggerTest(var level: Level, var traceEnabled: Boolean, var debugEna
 	private def mockLoggingProvider(): LoggingProvider = {
 		val provider = mock(classOf[LoggingProvider])
 
-		when(provider.getMinimumLevel(null)).thenReturn(level)
-		when(provider.isEnabled(anyInt, isNull[String], eqTo(Level.TRACE))).thenReturn(traceEnabled)
-		when(provider.isEnabled(anyInt, isNull[String], eqTo(Level.DEBUG))).thenReturn(debugEnabled)
-		when(provider.isEnabled(anyInt, isNull[String], eqTo(Level.INFO))).thenReturn(infoEnabled)
-		when(provider.isEnabled(anyInt, isNull[String], eqTo(Level.WARN))).thenReturn(warnEnabled)
-		when(provider.isEnabled(anyInt, isNull[String], eqTo(Level.ERROR))).thenReturn(errorEnabled)
+		when(provider.getMinimumLevel(null)).thenReturn(level.level)
+		when(provider.isEnabled(anyInt, isNull[String], eqTo(Level.TRACE))).thenReturn(level.traceEnabled)
+		when(provider.isEnabled(anyInt, isNull[String], eqTo(Level.DEBUG))).thenReturn(level.debugEnabled)
+		when(provider.isEnabled(anyInt, isNull[String], eqTo(Level.INFO))).thenReturn(level.infoEnabled)
+		when(provider.isEnabled(anyInt, isNull[String], eqTo(Level.WARN))).thenReturn(level.warnEnabled)
+		when(provider.isEnabled(anyInt, isNull[String], eqTo(Level.ERROR))).thenReturn(level.errorEnabled)
 
 		Whitebox.setInternalState(classOf[org.tinylog.Logger], provider)
-		Whitebox.setInternalState(classOf[org.tinylog.Logger], "MINIMUM_LEVEL_COVERS_TRACE", traceEnabled)
-		Whitebox.setInternalState(classOf[org.tinylog.Logger], "MINIMUM_LEVEL_COVERS_DEBUG", debugEnabled)
-		Whitebox.setInternalState(classOf[org.tinylog.Logger], "MINIMUM_LEVEL_COVERS_INFO", infoEnabled)
-		Whitebox.setInternalState(classOf[org.tinylog.Logger], "MINIMUM_LEVEL_COVERS_WARN", warnEnabled)
-		Whitebox.setInternalState(classOf[org.tinylog.Logger], "MINIMUM_LEVEL_COVERS_ERROR", errorEnabled)
+		Whitebox.setInternalState(classOf[org.tinylog.Logger], "MINIMUM_LEVEL_COVERS_TRACE", level.traceEnabled)
+		Whitebox.setInternalState(classOf[org.tinylog.Logger], "MINIMUM_LEVEL_COVERS_DEBUG", level.debugEnabled)
+		Whitebox.setInternalState(classOf[org.tinylog.Logger], "MINIMUM_LEVEL_COVERS_INFO", level.infoEnabled)
+		Whitebox.setInternalState(classOf[org.tinylog.Logger], "MINIMUM_LEVEL_COVERS_WARN", level.warnEnabled)
+		Whitebox.setInternalState(classOf[org.tinylog.Logger], "MINIMUM_LEVEL_COVERS_ERROR", level.errorEnabled)
 
 		return provider
 	}
@@ -829,14 +819,11 @@ object LoggerTest {
 		*/
 	@Parameters(name = "{0}") def getLevels: util.Collection[Array[AnyRef]] = {
 		val levels = new util.ArrayList[Array[AnyRef]]
-		// @formatter:off
-		levels.add(Array[AnyRef](Level.TRACE, Boolean.box(true),  Boolean.box(true),  Boolean.box(true),  Boolean.box(true),  Boolean.box(true)))
-		levels.add(Array[AnyRef](Level.DEBUG, Boolean.box(false), Boolean.box(true),  Boolean.box(true),  Boolean.box(true),  Boolean.box(true)))
-		levels.add(Array[AnyRef](Level.INFO,  Boolean.box(false), Boolean.box(false), Boolean.box(true),  Boolean.box(true),  Boolean.box(true)))
-		levels.add(Array[AnyRef](Level.WARN,  Boolean.box(false), Boolean.box(false), Boolean.box(false), Boolean.box(true),  Boolean.box(true)))
-		levels.add(Array[AnyRef](Level.ERROR, Boolean.box(false), Boolean.box(false), Boolean.box(false), Boolean.box(false), Boolean.box(true)))
-		levels.add(Array[AnyRef](Level.OFF,   Boolean.box(false), Boolean.box(false), Boolean.box(false), Boolean.box(false), Boolean.box(false)))
-		// @formatter:on
+
+		for (level <- LevelConfiguration.AVAILABLE_LEVELS) {
+			levels.add(Array[AnyRef](level))
+		}
+
 		levels
 	}
 

--- a/tinylog-api-scala/src/test/scala/org/tinylog/scala/TaggingTest.scala
+++ b/tinylog-api-scala/src/test/scala/org/tinylog/scala/TaggingTest.scala
@@ -39,18 +39,59 @@ final class TaggingTest {
 		*/
 	@Test def untagged(): Unit = {
 		val logger = Logger.tag(null)
-		assertThat(logger).isNotNull.isSameAs(Logger.tag(""))
-		assertThat(Whitebox.getInternalState[String](logger, "tag")).isNull()
+		assertThat(logger).isNotNull
+			.isSameAs(Logger.tag(""))
+			.isSameAs(Logger.tags())
+			.isSameAs(Logger.tags(null))
+			.isSameAs(Logger.tags(null, null))
+			.isSameAs(Logger.tags(null, ""))
+			.isSameAs(Logger.tags("", ""))
+		assertThat(Whitebox.getInternalState[Set[String]](logger, "tags")).isEqualTo(Set(null))
 	}
 
 	/**
-		* Verifies that [[org.tinylog.scala.Logger#tag(String)]] returns the same tagged instance of
+		* Verifies that [[org.tinylog.scala.Logger#tag(String, String*)]] with just one tag returns the same tagged instance of
 		* [[org.tinylog.scala.TaggedLogger]] for each tag.
 		*/
 	@Test def tagged(): Unit = {
 		val logger = Logger.tag("test")
-		assertThat(logger).isNotNull.isSameAs(Logger.tag("test")).isNotSameAs(Logger.tag("other"))
-		assertThat(Whitebox.getInternalState[String](logger, "tag")).isEqualTo("test")
+		assertThat(logger).isNotNull.isSameAs(Logger.tag("test")).isSameAs(Logger.tags("test"))
+			.isNotSameAs(Logger.tag("other"))
+		assertThat(Whitebox.getInternalState[Set[String]](logger, "tags")).isEqualTo(Set("test"))
 	}
 
+	/**
+		* Verifies that [[org.tinylog.scala.Logger#tag(String, String*)]] with more than one tag returns the same tagged instance of
+		* [[org.tinylog.scala.TaggedLogger]] for each tag.
+		*/
+	@Test def taggedMultiple(): Unit = {
+		val logger = Logger.tags("test", "more", "extra")
+
+		assertThat(logger).isNotNull()
+			.isSameAs(Logger.tags("extra", "more", "test"))
+			.isSameAs(Logger.tags("more", "test", "extra", "more", "extra", "test"))
+			.isNotSameAs(Logger.tag("other"))
+			.isNotSameAs(Logger.tags("test", "more"))
+		assertThat(Whitebox.getInternalState[Set[String]](logger, "tags")).isEqualTo(Set("test", "more", "extra"))
+	}
+
+	/**
+		* Verifies that {@link Logger#tags(String...)} with {@code null} tag mixed in returns the same tagged instance of
+		* {@link TaggedLogger} for each set of tags with more than one tag or if the same tag is repeated multiple times.
+		*/
+	@Test
+	def taggedMultipleWithNull(): Unit = {
+		val logger = Logger.tags("test", null, "more");
+
+		assertThat(logger).isNotNull()
+			.isSameAs(Logger.tags(null, "more", "test"))
+			.isSameAs(Logger.tags("", "more", "test"))
+			.isSameAs(Logger.tags("more", "test", null, "more", null, "test"))
+			.isSameAs(Logger.tags("more", "test", null, "more", "", "test"))
+			.isSameAs(Logger.tags("more", "test", "", "more", "", "test"))
+			.isNotSameAs(Logger.tag("other"))
+			.isNotSameAs(Logger.tags("test", "more"))
+			.isNotSameAs(Logger.tag(null))
+		assertThat(Whitebox.getInternalState[Set[String]](logger, "tags")).isEqualTo(Set("test", null, "more"))
+	}
 }

--- a/tinylog-api/src/test/java/org/tinylog/LevelConfiguration.java
+++ b/tinylog-api/src/test/java/org/tinylog/LevelConfiguration.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 Martin Winandy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.tinylog;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * This is intended to provide information about which log levels can be logged by a severity level. For example, TRACE is able to log all
+ * levels, whereas ERROR can log only at the ERROR level and OFF means none of the levels may be logged.
+ */
+public final class LevelConfiguration {
+
+	/**
+	 * List of all severity levels each other levels are "enabled" by them. The other level is enabled if it can be logged. This usually
+	 * means that the other level is also of a higher severity level.
+	 */
+	public static final Collection<LevelConfiguration> AVAILABLE_LEVELS = Collections.unmodifiableList(Arrays.asList(
+		new LevelConfiguration(Level.TRACE, true, true, true, true, true),
+		new LevelConfiguration(Level.DEBUG, false, true, true, true, true),
+		new LevelConfiguration(Level.INFO, false, false, true, true, true),
+		new LevelConfiguration(Level.WARN, false, false, false, true, true),
+		new LevelConfiguration(Level.ERROR, false, false, false, false, true),
+		new LevelConfiguration(Level.OFF, false, false, false, false, false)
+	));
+
+	private final Level level;
+	private final boolean traceEnabled;
+	private final boolean debugEnabled;
+	private final boolean infoEnabled;
+	private final boolean warnEnabled;
+	private final boolean errorEnabled;
+
+	/**
+	 * @param level
+	 *            Actual severity level
+	 * @param traceEnabled
+	 *            Determines if {@link Level#TRACE TRACE} level is enabled
+	 * @param debugEnabled
+	 *            Determines if {@link Level#DEBUG DEBUG} level is enabled
+	 * @param infoEnabled
+	 *            Determines if {@link Level#INFO INFO} level is enabled
+	 * @param warnEnabled
+	 *            Determines if {@link Level#WARN WARN} level is enabled
+	 * @param errorEnabled
+	 *            Determines if {@link Level#ERROR ERROR} level is enabled
+	 */
+	public LevelConfiguration(final Level level, final boolean traceEnabled, final boolean debugEnabled, final boolean infoEnabled,
+		final boolean warnEnabled, final boolean errorEnabled) {
+		this.level = level;
+		this.traceEnabled = traceEnabled;
+		this.debugEnabled = debugEnabled;
+		this.infoEnabled = infoEnabled;
+		this.warnEnabled = warnEnabled;
+		this.errorEnabled = errorEnabled;
+	}
+
+	/** @return the actual severity level */
+	public Level getLevel() {
+		return level;
+	}
+
+	/** @return {@code true} if the TRACE level is enabled for the severity {@link #level}, otherwise {@code false} */
+	public boolean isTraceEnabled() {
+		return traceEnabled;
+	}
+
+	/** @return {@code true} if the DEBUG level is enabled for the severity {@link #level}, otherwise {@code false} */
+	public boolean isDebugEnabled() {
+		return debugEnabled;
+	}
+
+	/** @return {@code true} if the INFO level is enabled for the severity {@link #level}, otherwise {@code false} */
+	public boolean isInfoEnabled() {
+		return infoEnabled;
+	}
+
+	/** @return {@code true} if the WARN level is enabled for the severity {@link #level}, otherwise {@code false} */
+	public boolean isWarnEnabled() {
+		return warnEnabled;
+	}
+
+	/** @return {@code true} if the ERROR level is enabled for the severity {@link #level}, otherwise {@code false} */
+	public boolean isErrorEnabled() {
+		return errorEnabled;
+	}
+
+	/**
+	 * @return a textual representation of the severity level
+	 */
+	@Override
+	public String toString() {
+		return level.toString();
+	}
+}


### PR DESCRIPTION
### Description

Linked issue: #201

This change allows a single `TaggedLogger` to log to multiple tags, instead of having to create individual logger for each tag.

### Definition of Done

- [x] I read [contributing.md](./contributing.md)
- [x] There are no TODOs left in the code
- [x] Code style follows the tinylog standard
- [x] All classes and methods have Javadoc
- [x] Changes are covered by JUnit tests including edge cases, errors, and exception handling
- [x] Maven build works including compiling, tests, and checks (`mvn verify`)
- [x] Changes are committed by a verified email address that is assigned to the GitHub account (https://github.com/settings/emails)

### Documentation

Additions or amendments for the [public documentation](https://github.com/pmwmedia/tinylog/wiki/Documentation):

- [Tags](https://github.com/tinylog-org/tinylog/wiki/Logging#tags) will need to be updated with the addition of the new `tags` method. 

### Agreements

- [x] I agree that my changes will be published under the terms of the [Apache License 2.0](https://github.com/pmwmedia/tinylog/blob/v2.0/license.txt) (mandatory)
- [x] I agree that my GitHub user name will be published in the release notes (optional)
