### PR TITLE
Support `max-size` and `size` modifiers to limit token length

### DIFF
--- a/tinylog-impl/src/main/java/org/tinylog/pattern/FormatPatternParser.java
+++ b/tinylog-impl/src/main/java/org/tinylog/pattern/FormatPatternParser.java
@@ -254,6 +254,8 @@ public final class FormatPatternParser {
 
 				if ("min-size".equals(key)) {
 					styledToken = new MinimumSizeToken(styledToken, number);
+				} else if ("max-size".equals(key)) {
+					styledToken = new MaximumSizeToken(styledToken, number);
 				} else if ("indent".equals(key)) {
 					styledToken = new IndentationToken(styledToken, number);
 				} else {

--- a/tinylog-impl/src/main/java/org/tinylog/pattern/FormatPatternParser.java
+++ b/tinylog-impl/src/main/java/org/tinylog/pattern/FormatPatternParser.java
@@ -256,6 +256,8 @@ public final class FormatPatternParser {
 					styledToken = new MinimumSizeToken(styledToken, number);
 				} else if ("max-size".equals(key)) {
 					styledToken = new MaximumSizeToken(styledToken, number);
+				} else if ("size".equals(key)) {
+					styledToken = new SizeToken(styledToken, number);
 				} else if ("indent".equals(key)) {
 					styledToken = new IndentationToken(styledToken, number);
 				} else {

--- a/tinylog-impl/src/main/java/org/tinylog/pattern/MaximumSizeToken.java
+++ b/tinylog-impl/src/main/java/org/tinylog/pattern/MaximumSizeToken.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 Victor Kropp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.tinylog.pattern;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collection;
+
+import org.tinylog.core.LogEntry;
+import org.tinylog.core.LogEntryValue;
+
+/**
+ * Decorator token for ensuring a maximum size. If the output of the underlying token is longer than the defined
+ * maximum size, start of the token will be trimmed.
+ */
+class MaximumSizeToken implements Token {
+
+	private final Token token;
+	private final int maximumSize;
+
+	/**
+	 * @param token
+	 *            Base token
+	 * @param size
+	 *            Maximum size for output
+	 */
+	MaximumSizeToken(final Token token, final int size) {
+		this.token = token;
+		this.maximumSize = size;
+	}
+
+	@Override
+	public Collection<LogEntryValue> getRequiredLogEntryValues() {
+		return token.getRequiredLogEntryValues();
+	}
+
+	@Override
+	public void render(final LogEntry logEntry, final StringBuilder builder) {
+		int offset = builder.length();
+		token.render(logEntry, builder);
+		int size = builder.length() - offset;
+
+		if (size > maximumSize) {
+			builder.delete(offset, offset + size - maximumSize);
+		}
+	}
+	
+	@Override
+	public void apply(final LogEntry logEntry, final PreparedStatement statement, final int index) throws SQLException {
+		StringBuilder builder = new StringBuilder();
+		render(logEntry, builder);
+		statement.setString(index, builder.toString());
+	}
+
+}

--- a/tinylog-impl/src/main/java/org/tinylog/pattern/SizeToken.java
+++ b/tinylog-impl/src/main/java/org/tinylog/pattern/SizeToken.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Victor Kropp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.tinylog.pattern;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collection;
+
+import org.tinylog.core.LogEntry;
+import org.tinylog.core.LogEntryValue;
+
+/**
+ * Decorator token for ensuring both minimum and maximum size. If the output of the underlying token is shorter
+ * or longer than the defined size, start of the token will be trimmed or padded with spaces at the end.
+ */
+class SizeToken implements Token {
+
+	private final Token token;
+	private final int size;
+
+	/**
+	 * @param token
+	 *            Base token
+	 * @param size
+	 *            Maximum size for output
+	 */
+	SizeToken(final Token token, final int size) {
+		this.token = token;
+		this.size = size;
+	}
+
+	@Override
+	public Collection<LogEntryValue> getRequiredLogEntryValues() {
+		return token.getRequiredLogEntryValues();
+	}
+
+	@Override
+	public void render(final LogEntry logEntry, final StringBuilder builder) {
+		int offset = builder.length();
+		token.render(logEntry, builder);
+		int size = builder.length() - offset;
+
+		if (size > this.size) {
+			builder.delete(offset, offset + size - this.size);
+		}
+		if (size < this.size) {
+			for (int i = 0; i < this.size - size; ++i) {
+				builder.append(' ');
+			}
+		}
+	}
+	
+	@Override
+	public void apply(final LogEntry logEntry, final PreparedStatement statement, final int index) throws SQLException {
+		StringBuilder builder = new StringBuilder();
+		render(logEntry, builder);
+		statement.setString(index, builder.toString());
+	}
+
+}

--- a/tinylog-impl/src/test/java/org/tinylog/pattern/FormatPatternParserTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/pattern/FormatPatternParserTest.java
@@ -424,6 +424,16 @@ public final class FormatPatternParserTest {
 	}
 
 	/**
+	 * Verifies that {@code {{any}:|size=X}} can be parsed and the returned token will apply both maximum and minimum size.
+	 */
+	@Test
+	public void size() {
+		String pattern = "{level} {message|size=7}";
+		assertThat(render(pattern, LogEntryBuilder.empty().message("short").level(Level.INFO).create())).isEqualTo("INFO short  ");
+		assertThat(render(pattern, LogEntryBuilder.empty().message("veryverylong").level(Level.INFO).create())).isEqualTo("INFO erylong");
+	}
+
+	/**
 	 * Verifies that invalid minimum size values will produce an error.
 	 */
 	@Test

--- a/tinylog-impl/src/test/java/org/tinylog/pattern/MaximumSizeTokenTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/pattern/MaximumSizeTokenTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2021 Victor Kropp, Martin Winandy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.tinylog.pattern;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.junit.Test;
+import org.tinylog.core.LogEntry;
+import org.tinylog.core.LogEntryValue;
+import org.tinylog.util.LogEntryBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link MaximumSizeToken}.
+ */
+public final class MaximumSizeTokenTest {
+
+	/**
+	 * Verifies that required log entry values from child token will be passed-through.
+	 */
+	@Test
+	public void requiredLogEntryValues() {
+		MaximumSizeToken token = new MaximumSizeToken(new SeverityLevelToken(), 10);
+		assertThat(token.getRequiredLogEntryValues()).containsOnly(LogEntryValue.LEVEL);
+	}
+
+	/**
+	 * Verifies that the text from a child token will be appended unmodified to a {@link StringBuilder}, if the text is
+	 * shorter than the defined maximum size.
+	 */
+	@Test
+	public void renderShorterTextThanMaximumSize() {
+		MaximumSizeToken token = new MaximumSizeToken(new PlainTextToken("Hello!"), 10);
+		assertThat(render(token)).isEqualTo("Hello!");
+	}
+
+	/**
+	 * Verifies that the text from a child token will be added unmodified to a {@link PreparedStatement}, if the text is
+	 * shorter than the defined maximum size.
+	 *
+	 * @throws SQLException
+	 *             Failed to add value to prepared SQL statement
+	 */
+	@Test
+	public void applyShorterTextThanMaximumSize() throws SQLException {
+		MaximumSizeToken token = new MaximumSizeToken(new PlainTextToken("Hello!"), 10);
+
+		PreparedStatement statement = mock(PreparedStatement.class);
+		token.apply(LogEntryBuilder.empty().create(), statement, 1);
+		verify(statement).setString(1, "Hello!");
+	}
+
+	/**
+	 * Verifies that the text from a child token will be appended unmodified to a {@link StringBuilder}, if the text
+	 * length is equal to the defined maximum size.
+	 */
+	@Test
+	public void renderTextOfEqualLengthToMaximumSize() {
+		MaximumSizeToken token = new MaximumSizeToken(new PlainTextToken("Hello!"), 6);
+		assertThat(render(token)).isEqualTo("Hello!");
+	}
+
+	/**
+	 * Verifies that the text from a child token will be added unmodified to a {@link PreparedStatement}, if the text
+	 * length is equal to the defined maximum size.
+	 *
+	 * @throws SQLException
+	 *             Failed to add value to prepared SQL statement
+	 */
+	@Test
+	public void applyTextOfEqualLengthToMaximumSize() throws SQLException {
+		MaximumSizeToken token = new MaximumSizeToken(new PlainTextToken("Hello!"), 6);
+
+		PreparedStatement statement = mock(PreparedStatement.class);
+		token.apply(LogEntryBuilder.empty().create(), statement, 1);
+		verify(statement).setString(1, "Hello!");
+	}
+
+	/**
+	 * Verifies that the text from a child token will be appended trimmed to a {@link StringBuilder}, if the
+	 * text is shorter than the defined minimum size.
+	 */
+	@Test
+	public void renderLongerTextThanMaximumSize() {
+		MaximumSizeToken token = new MaximumSizeToken(new PlainTextToken("Hello!"), 4);
+		assertThat(render(token)).isEqualTo("llo!");
+
+		token = new MaximumSizeToken(new PlainTextToken("Hello!"), 3);
+		assertThat(render(token)).isEqualTo("lo!");
+	}
+
+	/**
+	 * Verifies that the text from a child token will be appended trimmed to a {@link PreparedStatement}, if the
+	 * text is longer than the defined maximum size.
+	 *
+	 * @throws SQLException
+	 *             Failed to add value to prepared SQL statement
+	 */
+	@Test
+	public void applyLongerTextThanMaximumSize() throws SQLException {
+		PlainTextToken token = new PlainTextToken("Hello!");
+		LogEntry logEntry = LogEntryBuilder.empty().create();
+
+		PreparedStatement statement = mock(PreparedStatement.class);
+		new MaximumSizeToken(token, 4).apply(logEntry, statement, 1);
+		verify(statement).setString(1, "llo!");
+
+		statement = mock(PreparedStatement.class);
+		new MaximumSizeToken(token, 3).apply(logEntry, statement, 1);
+		verify(statement).setString(1, "lo!");
+	}
+
+	/**
+	 * Renders a token.
+	 *
+	 * @param token
+	 *            Token to render
+	 * @return Result text
+	 */
+	private static String render(final Token token) {
+		StringBuilder builder = new StringBuilder();
+		token.render(LogEntryBuilder.empty().create(), builder);
+		return builder.toString();
+	}
+
+}

--- a/tinylog-impl/src/test/java/org/tinylog/pattern/SizeTokenTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/pattern/SizeTokenTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2021 Victor Kropp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.tinylog.pattern;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.junit.Test;
+import org.tinylog.core.LogEntry;
+import org.tinylog.core.LogEntryValue;
+import org.tinylog.util.LogEntryBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link SizeToken}.
+ */
+public final class SizeTokenTest {
+
+	/**
+	 * Verifies that required log entry values from child token will be passed-through.
+	 */
+	@Test
+	public void requiredLogEntryValues() {
+		SizeToken token = new SizeToken(new SeverityLevelToken(), 10);
+		assertThat(token.getRequiredLogEntryValues()).containsOnly(LogEntryValue.LEVEL);
+	}
+
+	/**
+	 * Verifies that the text from a child token will be padded with spaces to a {@link StringBuilder}, if the text is
+	 * shorter than the defined size.
+	 */
+	@Test
+	public void renderShorterTextThanGivenSize() {
+		SizeToken token = new SizeToken(new PlainTextToken("Hello!"), 10);
+		assertThat(render(token)).isEqualTo("Hello!    ");
+	}
+
+	/**
+	 * Verifies that the text from a child token will be padded with spaces to a {@link PreparedStatement}, if the text is
+	 * shorter than the defined size.
+	 *
+	 * @throws SQLException
+	 *             Failed to add value to prepared SQL statement
+	 */
+	@Test
+	public void applyShorterTextThanGivenSize() throws SQLException {
+		SizeToken token = new SizeToken(new PlainTextToken("Hello!    "), 10);
+
+		PreparedStatement statement = mock(PreparedStatement.class);
+		token.apply(LogEntryBuilder.empty().create(), statement, 1);
+		verify(statement).setString(1, "Hello!    ");
+	}
+
+	/**
+	 * Verifies that the text from a child token will be appended unmodified to a {@link StringBuilder}, if the text
+	 * length is equal to the defined size.
+	 */
+	@Test
+	public void renderTextOfEqualLengthToGivenSize() {
+		SizeToken token = new SizeToken(new PlainTextToken("Hello!"), 6);
+		assertThat(render(token)).isEqualTo("Hello!");
+	}
+
+	/**
+	 * Verifies that the text from a child token will be added unmodified to a {@link PreparedStatement}, if the text
+	 * length is equal to the defined size.
+	 *
+	 * @throws SQLException
+	 *             Failed to add value to prepared SQL statement
+	 */
+	@Test
+	public void applyTextOfEqualLengthToGivenSize() throws SQLException {
+		SizeToken token = new SizeToken(new PlainTextToken("Hello!"), 6);
+
+		PreparedStatement statement = mock(PreparedStatement.class);
+		token.apply(LogEntryBuilder.empty().create(), statement, 1);
+		verify(statement).setString(1, "Hello!");
+	}
+
+	/**
+	 * Verifies that the text from a child token will be appended trimmed to a {@link StringBuilder}, if the
+	 * text is shorter than the defined minimum size.
+	 */
+	@Test
+	public void renderLongerTextThanGivenSize() {
+		SizeToken token = new SizeToken(new PlainTextToken("Hello!"), 4);
+		assertThat(render(token)).isEqualTo("llo!");
+
+		token = new SizeToken(new PlainTextToken("Hello!"), 3);
+		assertThat(render(token)).isEqualTo("lo!");
+	}
+
+	/**
+	 * Verifies that the text from a child token will be appended trimmed to a {@link PreparedStatement}, if the
+	 * text is longer than the defined size.
+	 *
+	 * @throws SQLException
+	 *             Failed to add value to prepared SQL statement
+	 */
+	@Test
+	public void applyLongerTextThanGivenSize() throws SQLException {
+		PlainTextToken token = new PlainTextToken("Hello!");
+		LogEntry logEntry = LogEntryBuilder.empty().create();
+
+		PreparedStatement statement = mock(PreparedStatement.class);
+		new SizeToken(token, 4).apply(logEntry, statement, 1);
+		verify(statement).setString(1, "llo!");
+
+		statement = mock(PreparedStatement.class);
+		new SizeToken(token, 3).apply(logEntry, statement, 1);
+		verify(statement).setString(1, "lo!");
+	}
+
+	/**
+	 * Renders a token.
+	 *
+	 * @param token
+	 *            Token to render
+	 * @return Result text
+	 */
+	private static String render(final Token token) {
+		StringBuilder builder = new StringBuilder();
+		token.render(LogEntryBuilder.empty().create(), builder);
+		return builder.toString();
+	}
+
+}


### PR DESCRIPTION
### Description

Linked issue: #219

### Definition of Done

- [x] I read [contributing.md](https://github.com/tinylog-org/tinylog/blob/v2.4/contributing.md)
- [x] There are no TODOs left in the code
- [x] Code style follows the tinylog standard
- [x] All classes and methods have Javadoc
- [x] Changes are covered by JUnit tests including edge cases, errors, and exception handling
- [x] Maven build works including compiling, tests, and checks (`mvn verify`)
- [x] Changes are committed by a verified email address that is assigned to the GitHub account (https://github.com/settings/emails)

### Documentation

Additions or amendments for the [public documentation](https://github.com/tinylog-org/tinylog/wiki/Documentation):

```markdown
Optionally, the minimum (`min-size`)/maximum (`max-size`)/fixed size (`size`) of a placeholder or a group of placeholders can be defined. For example, this is useful to format placeholders as columns.

Example:

writer        = console
writer.format = {{level}:|min-size=8,max-size=10} {message}
```

### Agreements

- [x] I agree that my changes will be published under the terms of the [Apache License 2.0](https://github.com/tinylog-org/tinylog/blob/v2.0/license.txt) (mandatory)
- [x] I agree that my GitHub user name will be published in the release notes (optional)
