### PR TITLE
Call getContextProvider

### DIFF
--- a/tinylog-impl/src/main/java/org/tinylog/core/TinylogLoggingProvider.java
+++ b/tinylog-impl/src/main/java/org/tinylog/core/TinylogLoggingProvider.java
@@ -142,7 +142,7 @@ public class TinylogLoggingProvider implements LoggingProvider {
 
 		if (activeLevel.ordinal() <= level.ordinal()) {
 			LogEntry logEntry = TinylogLoggingConfiguration.createLogEntry(stackTraceElement, tag, level, exception, formatter, 
-					obj, arguments, requiredLogEntryValues[tagIndex], context);
+					obj, arguments, requiredLogEntryValues[tagIndex], getContextProvider());
 			output(logEntry, writers[tagIndex][logEntry.getLevel().ordinal()]);
 		}
 	}
@@ -174,7 +174,7 @@ public class TinylogLoggingProvider implements LoggingProvider {
 
 		if (activeLevel.ordinal() <= level.ordinal()) {
 			LogEntry logEntry = TinylogLoggingConfiguration.createLogEntry(stackTraceElement, tag, level, exception, formatter,  
-					obj, arguments, requiredLogEntryValues[tagIndex], context);
+					obj, arguments, requiredLogEntryValues[tagIndex], getContextProvider());
 			output(logEntry, writers[tagIndex][logEntry.getLevel().ordinal()]);
 		}
 	}


### PR DESCRIPTION
Instead of accessing context directly get the contextProvider indirectly by calling getContext. This allows anyone who extends your class to override the contextProvider implementation.

### Description

Linked issue: #000

### Definition of Done

- [ x] I read [contributing.md](https://github.com/tinylog-org/tinylog/blob/v2.4/contributing.md)
- [ x] There are no TODOs left in the code
- [ x] Code style follows the tinylog standard
- [ x] All classes and methods have Javadoc
- [ x] Changes are covered by JUnit tests including edge cases, errors, and exception handling
- [ x] Maven build works including compiling, tests, and checks (`mvn verify`)
- [ x] Changes are committed by a verified email address that is assigned to the GitHub account (https://github.com/settings/emails)

### Documentation

Additions or amendments for the [public documentation](https://github.com/tinylog-org/tinylog/wiki/Documentation):

```markdown

```

### Agreements

- [ x] I agree that my changes will be published under the terms of the [Apache License 2.0](https://github.com/tinylog-org/tinylog/blob/v2.0/license.txt) (mandatory)
- [ x] I agree that my GitHub user name will be published in the release notes (optional)
