### PR TITLE
DynamicPolicy should continue existing file

### DIFF
--- a/tinylog-impl/src/main/java/org/tinylog/policies/DynamicPolicy.java
+++ b/tinylog-impl/src/main/java/org/tinylog/policies/DynamicPolicy.java
@@ -41,7 +41,7 @@ public final class DynamicPolicy implements Policy {
 
 	@Override
 	public boolean continueExistingFile(final String path) {
-		return !reset;
+		return true;
 	}
 
 	@Override

--- a/tinylog-impl/src/test/java/org/tinylog/policies/DynamicPolicyTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/policies/DynamicPolicyTest.java
@@ -47,7 +47,7 @@ public final class DynamicPolicyTest {
 		assertThat(policy.continueExistingFile(file)).isTrue();
 
 		DynamicPolicy.setReset();
-		assertThat(policy.continueExistingFile(file)).isFalse();
+		assertThat(policy.continueExistingFile(file)).isTrue();
 
 		policy.reset();
 		assertThat(policy.continueExistingFile(file)).isTrue();

--- a/tinylog-impl/src/test/java/org/tinylog/policies/DynamicPolicyTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/policies/DynamicPolicyTest.java
@@ -35,13 +35,13 @@ public final class DynamicPolicyTest {
 	public final SystemStreamCollector systemStream = new SystemStreamCollector(true);
 
 	/**
-	 * Verifies that an existing log file can be continued until triggering a manual reset.
+	 * Verifies that an existing log file will always be continued.
 	 * 
 	 * @throws IOException
 	 *             Failed creating temporary file
 	 */
 	@Test
-	public void discontinueExistingFile() throws IOException {
+	public void continueExistingFile() throws IOException {
 		String file = FileSystem.createTemporaryFile();
 		DynamicPolicy policy = new DynamicPolicy(null);
 		assertThat(policy.continueExistingFile(file)).isTrue();


### PR DESCRIPTION
When a job is run every minute, the log file should contain more than just the logs of the last execution.

### Description

Linked issue: #230 

### Definition of Done

- [x] I read [contributing.md](https://github.com/tinylog-org/tinylog/blob/v2.4/contributing.md)
- [x] There are no TODOs left in the code
- [x] Code style follows the tinylog standard
- [x] All classes and methods have Javadoc
- [x] Changes are covered by JUnit tests including edge cases, errors, and exception handling
- [x] Maven build works including compiling, tests, and checks (`mvn verify`)
- [x] Changes are committed by a verified email address that is assigned to the GitHub account (https://github.com/settings/emails)

### Documentation



### Agreements

- [x] I agree that my changes will be published under the terms of the [Apache License 2.0](https://github.com/tinylog-org/tinylog/blob/v2.0/license.txt) (mandatory)
- [x] I agree that my GitHub user name will be published in the release notes (optional)
