### PR TITLE
Add overloaded "isEnabled" method that takes loggerClassName instead of callerDepth (#381)

### DIFF
--- a/tinylog-api-kotlin/src/test/kotlin/org/tinylog/kotlin/LoggerTest.kt
+++ b/tinylog-api-kotlin/src/test/kotlin/org/tinylog/kotlin/LoggerTest.kt
@@ -113,11 +113,11 @@ class LoggerTest {
 		fun applyLoggingProvider() {
 			every { loggingProvider.getMinimumLevel(null) } returns level.level
 
-			every { loggingProvider.isEnabled(any(), null, Level.TRACE) } returns  level.traceEnabled
-			every { loggingProvider.isEnabled(any(), null, Level.DEBUG) } returns  level.debugEnabled
-			every { loggingProvider.isEnabled(any(), null, Level.INFO) } returns  level.infoEnabled
-			every { loggingProvider.isEnabled(any(), null, Level.WARN) } returns  level.warnEnabled
-			every { loggingProvider.isEnabled(any(), null, Level.ERROR) } returns  level.errorEnabled
+			every { loggingProvider.isEnabled(ofType(Int::class), null, Level.TRACE) } returns  level.traceEnabled
+			every { loggingProvider.isEnabled(ofType(Int::class), null, Level.DEBUG) } returns  level.debugEnabled
+			every { loggingProvider.isEnabled(ofType(Int::class), null, Level.INFO) } returns  level.infoEnabled
+			every { loggingProvider.isEnabled(ofType(Int::class), null, Level.WARN) } returns  level.warnEnabled
+			every { loggingProvider.isEnabled(ofType(Int::class), null, Level.ERROR) } returns  level.errorEnabled
 
 			every { loggingProvider.log(any<Int>(), any(), any(), any(), any(), any(), *anyVararg()) } returns Unit
 			every { loggingProvider.log(any<String>(), any(), any(), any(), any(), any(), *anyVararg()) } returns Unit

--- a/tinylog-api-kotlin/src/test/kotlin/org/tinylog/kotlin/TaggedLoggerTest.kt
+++ b/tinylog-api-kotlin/src/test/kotlin/org/tinylog/kotlin/TaggedLoggerTest.kt
@@ -101,22 +101,22 @@ class TaggedLoggerTest(private val tag1Configuration: LevelConfiguration, privat
 
 		every { loggingProvider.getMinimumLevel(tag1) } returns tag1Configuration.level
 
-		every { loggingProvider.isEnabled(any(), tag1, Level.TRACE) } returns tag1Configuration.traceEnabled
-		every { loggingProvider.isEnabled(any(), tag1, Level.DEBUG) } returns tag1Configuration.debugEnabled
-		every { loggingProvider.isEnabled(any(), tag1, Level.INFO) } returns tag1Configuration.infoEnabled
-		every { loggingProvider.isEnabled(any(), tag1, Level.WARN) } returns tag1Configuration.warnEnabled
-		every { loggingProvider.isEnabled(any(), tag1, Level.ERROR) } returns tag1Configuration.errorEnabled
+		every { loggingProvider.isEnabled(ofType(Int::class), tag1, Level.TRACE) } returns tag1Configuration.traceEnabled
+		every { loggingProvider.isEnabled(ofType(Int::class), tag1, Level.DEBUG) } returns tag1Configuration.debugEnabled
+		every { loggingProvider.isEnabled(ofType(Int::class), tag1, Level.INFO) } returns tag1Configuration.infoEnabled
+		every { loggingProvider.isEnabled(ofType(Int::class), tag1, Level.WARN) } returns tag1Configuration.warnEnabled
+		every { loggingProvider.isEnabled(ofType(Int::class), tag1, Level.ERROR) } returns tag1Configuration.errorEnabled
 
 		logger = if (tag2Configuration == null) {
 			TaggedLogger(setOf(tag1))
 		} else {
 			every { loggingProvider.getMinimumLevel(tag2) } returns tag2Configuration.level
 
-			every { loggingProvider.isEnabled(any(), tag2, Level.TRACE) } returns tag2Configuration.traceEnabled
-			every { loggingProvider.isEnabled(any(), tag2, Level.DEBUG) } returns tag2Configuration.debugEnabled
-			every { loggingProvider.isEnabled(any(), tag2, Level.INFO) } returns tag2Configuration.infoEnabled
-			every { loggingProvider.isEnabled(any(), tag2, Level.WARN) } returns tag2Configuration.warnEnabled
-			every { loggingProvider.isEnabled(any(), tag2, Level.ERROR) } returns tag2Configuration.errorEnabled
+			every { loggingProvider.isEnabled(ofType(Int::class), tag2, Level.TRACE) } returns tag2Configuration.traceEnabled
+			every { loggingProvider.isEnabled(ofType(Int::class), tag2, Level.DEBUG) } returns tag2Configuration.debugEnabled
+			every { loggingProvider.isEnabled(ofType(Int::class), tag2, Level.INFO) } returns tag2Configuration.infoEnabled
+			every { loggingProvider.isEnabled(ofType(Int::class), tag2, Level.WARN) } returns tag2Configuration.warnEnabled
+			every { loggingProvider.isEnabled(ofType(Int::class), tag2, Level.ERROR) } returns tag2Configuration.errorEnabled
 			TaggedLogger(setOf(tag1, tag2))
 		}
 

--- a/tinylog-api/src/main/java/org/tinylog/provider/BundleLoggingProvider.java
+++ b/tinylog-api/src/main/java/org/tinylog/provider/BundleLoggingProvider.java
@@ -69,12 +69,21 @@ public final class BundleLoggingProvider implements LoggingProvider {
 
 	@Override
 	public boolean isEnabled(final int depth, final String tag, final Level level) {
-		for (int i = 0; i < loggingProviders.length; ++i) {
-			if (loggingProviders[i].isEnabled(depth + 1, tag, level)) {
+		for (LoggingProvider loggingProvider : loggingProviders) {
+			if (loggingProvider.isEnabled(depth + 1, tag, level)) {
 				return true;
 			}
 		}
+		return false;
+	}
 
+	@Override
+	public boolean isEnabled(final String loggerClassName, final String tag, final Level level) {
+		for (LoggingProvider loggingProvider : loggingProviders) {
+			if (loggingProvider.isEnabled(loggerClassName, tag, level)) {
+				return true;
+			}
+		}
 		return false;
 	}
 

--- a/tinylog-api/src/main/java/org/tinylog/provider/LoggingProvider.java
+++ b/tinylog-api/src/main/java/org/tinylog/provider/LoggingProvider.java
@@ -73,6 +73,19 @@ public interface LoggingProvider {
 	boolean isEnabled(int depth, String tag, Level level);
 
 	/**
+	 * Checks whether log entries, issued by the caller of the given logger class, with given tag and severity level will be output.
+	 *
+	 * @param loggerClassName
+	 *     Fully-qualified class name of the logger instance
+	 * @param tag
+	 *     Tag to check (can be {@code null})
+	 * @param level
+	 *     Severity level to check
+	 * @return {@code true} if given severity level is enabled, {@code false} if disabled
+	 */
+	boolean isEnabled(String loggerClassName, String tag, Level level);
+
+	/**
 	 * Provides a regular log entry.
 	 *
 	 * @param depth
@@ -117,7 +130,7 @@ public interface LoggingProvider {
 	/**
 	 * Shuts down the logging provider and frees all allocated resources. This method should be called only if auto
 	 * shutdown is explicitly disabled.
-	 * 
+	 *
 	 * @throws InterruptedException
 	 *             Interrupted while waiting for complete shutdown
 	 */

--- a/tinylog-api/src/main/java/org/tinylog/provider/NopLoggingProvider.java
+++ b/tinylog-api/src/main/java/org/tinylog/provider/NopLoggingProvider.java
@@ -48,6 +48,11 @@ public final class NopLoggingProvider implements LoggingProvider {
 	}
 
 	@Override
+	public boolean isEnabled(final String loggerClassName, final String tag, final Level level) {
+		return false;
+	}
+
+	@Override
 	public void log(final int depth, final String tag, final Level level, final Throwable exception, final MessageFormatter formatter,
 		final Object obj, final Object... arguments) {
 		// Ignore

--- a/tinylog-api/src/test/java/org/tinylog/provider/BundleLoggingProviderTest.java
+++ b/tinylog-api/src/test/java/org/tinylog/provider/BundleLoggingProviderTest.java
@@ -21,6 +21,7 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atLeastOnce;
@@ -120,6 +121,36 @@ public final class BundleLoggingProviderTest {
 
 		verify(first, atLeastOnce()).isEnabled(eq(2), isNull(), any());
 		verify(second, atLeastOnce()).isEnabled(eq(2), isNull(), any());
+	}
+
+	/**
+	 * Verifies that {@code isEnabled} method evaluates the severity level from underlying logging providers and
+	 * returns {@code true} if given severity level is enabled at least for one of the underlying logging providers.
+	 */
+	@Test
+	public void isEnabledWithLoggerClassName() {
+		init(Level.TRACE, Level.TRACE);
+
+		when(first.isEnabled(anyString(), isNull(), eq(Level.TRACE))).thenReturn(false);
+		when(first.isEnabled(anyString(), isNull(), eq(Level.DEBUG))).thenReturn(false);
+		when(first.isEnabled(anyString(), isNull(), eq(Level.INFO))).thenReturn(false);
+		when(first.isEnabled(anyString(), isNull(), eq(Level.WARN))).thenReturn(true);
+		when(first.isEnabled(anyString(), isNull(), eq(Level.ERROR))).thenReturn(true);
+
+		when(second.isEnabled(anyString(), isNull(), eq(Level.TRACE))).thenReturn(false);
+		when(second.isEnabled(anyString(), isNull(), eq(Level.DEBUG))).thenReturn(true);
+		when(second.isEnabled(anyString(), isNull(), eq(Level.INFO))).thenReturn(true);
+		when(second.isEnabled(anyString(), isNull(), eq(Level.WARN))).thenReturn(true);
+		when(second.isEnabled(anyString(), isNull(), eq(Level.ERROR))).thenReturn(true);
+
+		assertThat(bundle.isEnabled("myLoggerClassName", null, Level.TRACE)).isFalse();
+		assertThat(bundle.isEnabled("myLoggerClassName", null, Level.DEBUG)).isTrue();
+		assertThat(bundle.isEnabled("myLoggerClassName", null, Level.INFO)).isTrue();
+		assertThat(bundle.isEnabled("myLoggerClassName", null, Level.WARN)).isTrue();
+		assertThat(bundle.isEnabled("myLoggerClassName", null, Level.ERROR)).isTrue();
+
+		verify(first, atLeastOnce()).isEnabled(eq("myLoggerClassName"), isNull(), any());
+		verify(second, atLeastOnce()).isEnabled(eq("myLoggerClassName"), isNull(), any());
 	}
 
 	/**

--- a/tinylog-api/src/test/java/org/tinylog/provider/BundleLoggingProviderTest.java
+++ b/tinylog-api/src/test/java/org/tinylog/provider/BundleLoggingProviderTest.java
@@ -124,7 +124,7 @@ public final class BundleLoggingProviderTest {
 	}
 
 	/**
-	 * Verifies that {@code isEnabled()} method evaluates the severity level from underlying logging providers and
+	 * Verifies that {@code isEnabled()} evaluates the severity level from underlying logging providers and
 	 * returns {@code true} if the given severity level is enabled at least for one of the underlying logging providers.
 	 */
 	@Test

--- a/tinylog-api/src/test/java/org/tinylog/provider/BundleLoggingProviderTest.java
+++ b/tinylog-api/src/test/java/org/tinylog/provider/BundleLoggingProviderTest.java
@@ -124,8 +124,8 @@ public final class BundleLoggingProviderTest {
 	}
 
 	/**
-	 * Verifies that {@code isEnabled} method evaluates the severity level from underlying logging providers and
-	 * returns {@code true} if given severity level is enabled at least for one of the underlying logging providers.
+	 * Verifies that {@code isEnabled()} method evaluates the severity level from underlying logging providers and
+	 * returns {@code true} if the given severity level is enabled at least for one of the underlying logging providers.
 	 */
 	@Test
 	public void isEnabledWithLoggerClassName() {

--- a/tinylog-api/src/test/java/org/tinylog/provider/NopLoggingProviderTest.java
+++ b/tinylog-api/src/test/java/org/tinylog/provider/NopLoggingProviderTest.java
@@ -70,11 +70,11 @@ public final class NopLoggingProviderTest {
 		assertThat(provider.isEnabled(3, null, Level.WARN)).isFalse();
 		assertThat(provider.isEnabled(4, null, Level.ERROR)).isFalse();
 
-		assertThat(provider.isEnabled("anyClassName", null, Level.TRACE)).isFalse();
-		assertThat(provider.isEnabled("anyClassName", null, Level.DEBUG)).isFalse();
-		assertThat(provider.isEnabled("anyClassName", null, Level.INFO)).isFalse();
-		assertThat(provider.isEnabled("anyClassName", null, Level.WARN)).isFalse();
-		assertThat(provider.isEnabled("anyClassName", null, Level.ERROR)).isFalse();
+		assertThat(provider.isEnabled("any.fully.qualified.class.Name", null, Level.TRACE)).isFalse();
+		assertThat(provider.isEnabled("any.fully.qualified.class.Name", null, Level.DEBUG)).isFalse();
+		assertThat(provider.isEnabled("any.fully.qualified.class.Name", null, Level.INFO)).isFalse();
+		assertThat(provider.isEnabled("any.fully.qualified.class.Name", null, Level.WARN)).isFalse();
+		assertThat(provider.isEnabled("any.fully.qualified.class.Name", null, Level.ERROR)).isFalse();
 	}
 
 	/**
@@ -88,11 +88,11 @@ public final class NopLoggingProviderTest {
 		assertThat(provider.isEnabled(3, "test", Level.WARN)).isFalse();
 		assertThat(provider.isEnabled(4, "test", Level.ERROR)).isFalse();
 
-		assertThat(provider.isEnabled("anyClassName", "test", Level.TRACE)).isFalse();
-		assertThat(provider.isEnabled("anyClassName", "test", Level.DEBUG)).isFalse();
-		assertThat(provider.isEnabled("anyClassName", "test", Level.INFO)).isFalse();
-		assertThat(provider.isEnabled("anyClassName", "test", Level.WARN)).isFalse();
-		assertThat(provider.isEnabled("anyClassName", "test", Level.ERROR)).isFalse();
+		assertThat(provider.isEnabled("any.fully.qualified.class.Name", "test", Level.TRACE)).isFalse();
+		assertThat(provider.isEnabled("any.fully.qualified.class.Name", "test", Level.DEBUG)).isFalse();
+		assertThat(provider.isEnabled("any.fully.qualified.class.Name", "test", Level.INFO)).isFalse();
+		assertThat(provider.isEnabled("any.fully.qualified.class.Name", "test", Level.WARN)).isFalse();
+		assertThat(provider.isEnabled("any.fully.qualified.class.Name", "test", Level.ERROR)).isFalse();
 	}
 
 	/**

--- a/tinylog-api/src/test/java/org/tinylog/provider/NopLoggingProviderTest.java
+++ b/tinylog-api/src/test/java/org/tinylog/provider/NopLoggingProviderTest.java
@@ -69,6 +69,12 @@ public final class NopLoggingProviderTest {
 		assertThat(provider.isEnabled(2, null, Level.INFO)).isFalse();
 		assertThat(provider.isEnabled(3, null, Level.WARN)).isFalse();
 		assertThat(provider.isEnabled(4, null, Level.ERROR)).isFalse();
+
+		assertThat(provider.isEnabled("anyClassName", null, Level.TRACE)).isFalse();
+		assertThat(provider.isEnabled("anyClassName", null, Level.DEBUG)).isFalse();
+		assertThat(provider.isEnabled("anyClassName", null, Level.INFO)).isFalse();
+		assertThat(provider.isEnabled("anyClassName", null, Level.WARN)).isFalse();
+		assertThat(provider.isEnabled("anyClassName", null, Level.ERROR)).isFalse();
 	}
 
 	/**
@@ -81,6 +87,12 @@ public final class NopLoggingProviderTest {
 		assertThat(provider.isEnabled(2, "test", Level.INFO)).isFalse();
 		assertThat(provider.isEnabled(3, "test", Level.WARN)).isFalse();
 		assertThat(provider.isEnabled(4, "test", Level.ERROR)).isFalse();
+
+		assertThat(provider.isEnabled("anyClassName", "test", Level.TRACE)).isFalse();
+		assertThat(provider.isEnabled("anyClassName", "test", Level.DEBUG)).isFalse();
+		assertThat(provider.isEnabled("anyClassName", "test", Level.INFO)).isFalse();
+		assertThat(provider.isEnabled("anyClassName", "test", Level.WARN)).isFalse();
+		assertThat(provider.isEnabled("anyClassName", "test", Level.ERROR)).isFalse();
 	}
 
 	/**

--- a/tinylog-api/src/test/java/org/tinylog/provider/ProviderRegistryTest.java
+++ b/tinylog-api/src/test/java/org/tinylog/provider/ProviderRegistryTest.java
@@ -312,6 +312,11 @@ public final class ProviderRegistryTest {
 		}
 
 		@Override
+		public final boolean isEnabled(final String loggerClassName, final String tag, final Level level) {
+			return false;
+		}
+
+		@Override
 		public final void log(final int depth, final String tag, final Level level, final Throwable exception,
 			final MessageFormatter formatter, final Object obj, final Object... arguments) {
 		}

--- a/tinylog-impl/src/main/java/org/tinylog/core/TinylogLoggingProvider.java
+++ b/tinylog-impl/src/main/java/org/tinylog/core/TinylogLoggingProvider.java
@@ -89,7 +89,7 @@ public class TinylogLoggingProvider implements LoggingProvider {
 		Level level = Level.OFF;
 		for (int tagIndex = 0; tagIndex < writers.length; ++tagIndex) {
 			for (int levelIndex = Level.TRACE.ordinal(); levelIndex < level.ordinal(); ++levelIndex) {
-				if (writers[tagIndex][levelIndex].size() > 0) {
+				if (!writers[tagIndex][levelIndex].isEmpty()) {
 					level = Level.values()[levelIndex];
 				}
 			}
@@ -101,7 +101,7 @@ public class TinylogLoggingProvider implements LoggingProvider {
 	public Level getMinimumLevel(final String tag) {
 		int tagIndex = getTagIndex(tag);
 		for (int levelIndex = Level.TRACE.ordinal(); levelIndex < Level.OFF.ordinal(); ++levelIndex) {
-			if (writers[tagIndex][levelIndex].size() > 0) {
+			if (!writers[tagIndex][levelIndex].isEmpty()) {
 				return Level.values()[levelIndex];
 			}
 		}
@@ -110,16 +110,17 @@ public class TinylogLoggingProvider implements LoggingProvider {
 
 	@Override
 	public boolean isEnabled(final int depth, final String tag, final Level level) {
-		Level activeLevel;
+		return isLoggable(RuntimeProvider.getCallerClassName(depth + 1), level, tag);
+	}
 
-		if (customLevels.isEmpty()) {
-			activeLevel = globalLevel;
-		} else {
-			String className = RuntimeProvider.getCallerClassName(depth + 1);
-			activeLevel = getLevel(className);
-		}
+	@Override
+	public boolean isEnabled(final String loggerClassName, final String tag, final Level level) {
+		return isLoggable(RuntimeProvider.getCallerClassName(loggerClassName), level, tag);
+	}
 
-		return activeLevel.ordinal() <= level.ordinal() && writers[getTagIndex(tag)][level.ordinal()].size() > 0;
+	private boolean isLoggable(final String callerClassName, final Level level, final String tag) {
+		Level activeLevel = customLevels.isEmpty() ? globalLevel : getLevel(callerClassName);
+		return activeLevel.ordinal() <= level.ordinal() && !writers[getTagIndex(tag)][level.ordinal()].isEmpty();
 	}
 
 	@Override

--- a/tinylog-impl/src/test/java/org/tinylog/core/TinylogLoggingProviderTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/core/TinylogLoggingProviderTest.java
@@ -97,6 +97,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void traceEnabled() {
 			assertThat(provider.isEnabled(1, tag, Level.TRACE)).isTrue();
+			assertThat(provider.isEnabled(provider.getClass().getName(), tag, Level.TRACE)).isTrue();
 
 			provider.log(1, tag, Level.TRACE, null, null, "Hello World!");
 			assertThat(systemStream.consumeStandardOutput()).containsOnlyOnce("TRACE").containsOnlyOnce("Hello World!");
@@ -111,6 +112,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void debugEnabled() {
 			assertThat(provider.isEnabled(1, tag, Level.DEBUG)).isTrue();
+			assertThat(provider.isEnabled(provider.getClass().getName(), tag, Level.DEBUG)).isTrue();
 
 			provider.log(1, tag, Level.DEBUG, null, null, "Hello World!");
 			assertThat(systemStream.consumeStandardOutput()).containsOnlyOnce("DEBUG").containsOnlyOnce("Hello World!");
@@ -125,6 +127,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void infoEnabled() {
 			assertThat(provider.isEnabled(1, tag, Level.INFO)).isTrue();
+			assertThat(provider.isEnabled(provider.getClass().getName(), tag, Level.INFO)).isTrue();
 
 			provider.log(1, tag, Level.INFO, null, null, "Hello World!");
 			assertThat(systemStream.consumeStandardOutput()).containsOnlyOnce("INFO").containsOnlyOnce("Hello World!");
@@ -139,6 +142,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void warningEnabled() {
 			assertThat(provider.isEnabled(1, tag, Level.WARN)).isTrue();
+			assertThat(provider.isEnabled(provider.getClass().getName(), tag, Level.WARN)).isTrue();
 
 			provider.log(1, tag, Level.WARN, null, null, "Hello World!");
 			assertThat(systemStream.consumeErrorOutput()).containsOnlyOnce("WARN").containsOnlyOnce("Hello World!");
@@ -153,6 +157,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void errorEnabled() {
 			assertThat(provider.isEnabled(1, tag, Level.ERROR)).isTrue();
+			assertThat(provider.isEnabled(provider.getClass().getName(), tag, Level.ERROR)).isTrue();
 
 			provider.log(1, tag, Level.ERROR, null, null, "Hello World!");
 			assertThat(systemStream.consumeErrorOutput()).containsOnlyOnce("ERROR").containsOnlyOnce("Hello World!");
@@ -210,6 +215,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void traceDisabled() {
 			assertThat(provider.isEnabled(1, tag, Level.TRACE)).isFalse();
+			assertThat(provider.isEnabled(provider.getClass().getName(), tag, Level.TRACE)).isFalse();
 
 			provider.log(1, tag, Level.TRACE, null, null, "Hello World!");
 			assertThat(systemStream.consumeStandardOutput()).isEmpty();
@@ -224,6 +230,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void debugDisabled() {
 			assertThat(provider.isEnabled(1, tag, Level.DEBUG)).isFalse();
+			assertThat(provider.isEnabled(provider.getClass().getName(), tag, Level.DEBUG)).isFalse();
 
 			provider.log(1, tag, Level.DEBUG, null, null, "Hello World!");
 			assertThat(systemStream.consumeStandardOutput()).isEmpty();
@@ -238,6 +245,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void infoDisabled() {
 			assertThat(provider.isEnabled(1, tag, Level.INFO)).isFalse();
+			assertThat(provider.isEnabled(provider.getClass().getName(), tag, Level.INFO)).isFalse();
 
 			provider.log(1, tag, Level.INFO, null, null, "Hello World!");
 			assertThat(systemStream.consumeStandardOutput()).isEmpty();
@@ -252,6 +260,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void warningDisabled() {
 			assertThat(provider.isEnabled(1, tag, Level.WARN)).isFalse();
+			assertThat(provider.isEnabled(provider.getClass().getName(), tag, Level.WARN)).isFalse();
 
 			provider.log(1, tag, Level.WARN, null, null, "Hello World!");
 			assertThat(systemStream.consumeErrorOutput()).isEmpty();
@@ -266,6 +275,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void errorDisabled() {
 			assertThat(provider.isEnabled(1, tag, Level.ERROR)).isFalse();
+			assertThat(provider.isEnabled(provider.getClass().getName(), tag, Level.ERROR)).isFalse();
 
 			provider.log(1, tag, Level.ERROR, null, null, "Hello World!");
 			assertThat(systemStream.consumeErrorOutput()).isEmpty();
@@ -522,6 +532,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void untaggedTraceEnabled() {
 			assertThat(provider.isEnabled(1, null, Level.TRACE)).isTrue();
+			assertThat(provider.isEnabled(provider.getClass().getName(), null, Level.TRACE)).isTrue();
 
 			provider.log(1, null, Level.TRACE, null, null, "Hello World!");
 			assertThat(systemStream.consumeStandardOutput()).isEqualTo(Level.TRACE + ": Hello World!" + NEW_LINE);
@@ -536,6 +547,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void taggedTraceDisabled() {
 			assertThat(provider.isEnabled(1, "test", Level.TRACE)).isFalse();
+			assertThat(provider.isEnabled(provider.getClass().getName(), "test", Level.TRACE)).isFalse();
 
 			provider.log(1, "test", Level.TRACE, null, null, "Hello World!");
 			assertThat(systemStream.consumeStandardOutput()).isEmpty();
@@ -550,6 +562,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void untaggedDebugEnabled() {
 			assertThat(provider.isEnabled(1, null, Level.DEBUG)).isTrue();
+			assertThat(provider.isEnabled(provider.getClass().getName(), null, Level.DEBUG)).isTrue();
 
 			provider.log(1, null, Level.DEBUG, null, null, "Hello World!");
 			assertThat(systemStream.consumeStandardOutput()).isEqualTo(Level.DEBUG + ": Hello World!" + NEW_LINE);
@@ -564,6 +577,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void taggedDebugDisabled() {
 			assertThat(provider.isEnabled(1, "test", Level.DEBUG)).isFalse();
+			assertThat(provider.isEnabled(provider.getClass().getName(), "test", Level.DEBUG)).isFalse();
 
 			provider.log(1, "test", Level.DEBUG, null, null, "Hello World!");
 			assertThat(systemStream.consumeStandardOutput()).isEmpty();
@@ -578,6 +592,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void untaggedInfoEnabled() {
 			assertThat(provider.isEnabled(1, null, Level.INFO)).isTrue();
+			assertThat(provider.isEnabled(provider.getClass().getName(), null, Level.INFO)).isTrue();
 
 			provider.log(1, null, Level.INFO, null, null, "Hello World!");
 			assertThat(systemStream.consumeStandardOutput()).isEqualTo(Level.INFO + ": Hello World!" + NEW_LINE);
@@ -592,6 +607,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void taggedInfoEnabled() {
 			assertThat(provider.isEnabled(1, "test", Level.INFO)).isTrue();
+			assertThat(provider.isEnabled(provider.getClass().getName(), "test", Level.INFO)).isTrue();
 
 			provider.log(1, "test", Level.INFO, null, null, "Hello World!");
 			assertThat(systemStream.consumeStandardOutput()).isEqualTo(Level.INFO + ": Hello World!" + NEW_LINE);
@@ -606,6 +622,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void untaggedWarningEnabled() {
 			assertThat(provider.isEnabled(1, null, Level.WARN)).isTrue();
+			assertThat(provider.isEnabled(provider.getClass().getName(), null, Level.WARN)).isTrue();
 
 			provider.log(1, null, Level.WARN, null, null, "Hello World!");
 			assertThat(systemStream.consumeErrorOutput()).isEqualTo(Level.WARN + ": Hello World!" + NEW_LINE);
@@ -620,6 +637,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void taggedWarningEnabled() {
 			assertThat(provider.isEnabled(1, "test", Level.WARN)).isTrue();
+			assertThat(provider.isEnabled(provider.getClass().getName(), "test", Level.WARN)).isTrue();
 
 			provider.log(1, "test", Level.WARN, null, null, "Hello World!");
 			assertThat(systemStream.consumeErrorOutput()).isEqualTo(Level.WARN + ": Hello World!" + NEW_LINE);
@@ -634,6 +652,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void untaggedErrorEnabled() {
 			assertThat(provider.isEnabled(1, null, Level.ERROR)).isTrue();
+			assertThat(provider.isEnabled(provider.getClass().getName(), null, Level.ERROR)).isTrue();
 
 			provider.log(1, null, Level.ERROR, null, null, "Hello World!");
 			assertThat(systemStream.consumeErrorOutput()).isEqualTo(Level.ERROR + ": Hello World!" + NEW_LINE);
@@ -648,6 +667,7 @@ public final class TinylogLoggingProviderTest {
 		@Test
 		public void taggedErrorEnabled() {
 			assertThat(provider.isEnabled(1, "test", Level.ERROR)).isTrue();
+			assertThat(provider.isEnabled(provider.getClass().getName(), "test", Level.ERROR)).isTrue();
 
 			provider.log(1, "test", Level.ERROR, null, null, "Hello World!");
 			assertThat(systemStream.consumeErrorOutput()).isEqualTo(Level.ERROR + ": Hello World!" + NEW_LINE);

--- a/tinylog-jboss/src/main/java/org/tinylog/adapter/jboss/JBossLoggingProvider.java
+++ b/tinylog-jboss/src/main/java/org/tinylog/adapter/jboss/JBossLoggingProvider.java
@@ -49,8 +49,12 @@ public final class JBossLoggingProvider implements LoggingProvider {
 
 	@Override
 	public boolean isEnabled(final int depth, final String tag, final Level level) {
-		String callerClassName = RuntimeProvider.getCallerClassName(depth + 1);
-		return Logger.getLogger(callerClassName).isEnabled(translate(level));
+		return isLoggable(RuntimeProvider.getCallerClassName(depth + 1), level);
+	}
+
+	@Override
+	public boolean isEnabled(final String loggerClassName, final String tag, final Level level) {
+		return isLoggable(RuntimeProvider.getCallerClassName(loggerClassName), level);
 	}
 
 	@Override
@@ -87,7 +91,7 @@ public final class JBossLoggingProvider implements LoggingProvider {
 
 	/**
 	 * Translates a tinylog severity level into a JBoss Logging level.
-	 * 
+	 *
 	 * @param level
 	 *            Severity level of tinylog
 	 * @return Corresponding level of JBoss Logging
@@ -109,4 +113,7 @@ public final class JBossLoggingProvider implements LoggingProvider {
 		}
 	}
 
+	private static boolean isLoggable(final String callerClassName, final Level level) {
+		return Logger.getLogger(callerClassName).isEnabled(translate(level));
+	}
 }

--- a/tinylog-jboss/src/test/java/org/tinylog/adapter/jboss/JBossLoggingProviderTest.java
+++ b/tinylog-jboss/src/test/java/org/tinylog/adapter/jboss/JBossLoggingProviderTest.java
@@ -101,6 +101,19 @@ public final class JBossLoggingProviderTest {
 	}
 
 	/**
+	 * Verifies that {@link Level#INFO}, {@link Level#WARN}, and {@link Level#ERROR} are enabled.
+	 */
+	@Test
+	public void enabledWithLoggerClassName() {
+		JBossLoggingProvider provider = new JBossLoggingProvider();
+
+		String effectualLoggerClassName = JBossLoggingProvider.class.getName();
+		assertThat(provider.isEnabled(effectualLoggerClassName, null, Level.INFO)).isTrue();
+		assertThat(provider.isEnabled(effectualLoggerClassName, null, Level.WARN)).isTrue();
+		assertThat(provider.isEnabled(effectualLoggerClassName, null, Level.ERROR)).isTrue();
+	}
+
+	/**
 	 * Verifies that {@link Level#TRACE} and {@link Level#DEBUG} are disabled.
 	 */
 	@Test
@@ -109,6 +122,18 @@ public final class JBossLoggingProviderTest {
 
 		assertThat(provider.isEnabled(1, null, Level.TRACE)).isFalse();
 		assertThat(provider.isEnabled(1, null, Level.DEBUG)).isFalse();
+	}
+
+	/**
+	 * Verifies that {@link Level#TRACE} and {@link Level#DEBUG} are disabled.
+	 */
+	@Test
+	public void disabledWithLoggerClassName() {
+		JBossLoggingProvider provider = new JBossLoggingProvider();
+
+		String effectualLoggerClassName = JBossLoggingProvider.class.getName();
+		assertThat(provider.isEnabled(effectualLoggerClassName, null, Level.TRACE)).isFalse();
+		assertThat(provider.isEnabled(effectualLoggerClassName, null, Level.DEBUG)).isFalse();
 	}
 
 	/**

--- a/tinylog-jul/src/main/java/org/tinylog/adapter/jul/JavaUtilLoggingProvider.java
+++ b/tinylog-jul/src/main/java/org/tinylog/adapter/jul/JavaUtilLoggingProvider.java
@@ -51,8 +51,12 @@ public final class JavaUtilLoggingProvider implements LoggingProvider {
 
 	@Override
 	public boolean isEnabled(final int depth, final String tag, final Level level) {
-		String callerClassName = RuntimeProvider.getCallerClassName(depth + 1);
-		return Logger.getLogger(callerClassName).isLoggable(translate(level));
+		return isLoggable(RuntimeProvider.getCallerClassName(depth + 1), level);
+	}
+
+	@Override
+	public boolean isEnabled(final String loggerClassName, final String tag, final Level level) {
+		return isLoggable(RuntimeProvider.getCallerClassName(loggerClassName), level);
 	}
 
 	@Override
@@ -61,7 +65,7 @@ public final class JavaUtilLoggingProvider implements LoggingProvider {
 		StackTraceElement caller = RuntimeProvider.getCallerStackTraceElement(depth + 1);
 		Logger julLogger = Logger.getLogger(caller.getClassName());
 		java.util.logging.Level julLevel = translate(level);
-		
+
 		if (julLogger.isLoggable(julLevel)) {
 			String message = String.valueOf(obj);
 			if (arguments != null && arguments.length > 0) {
@@ -77,7 +81,7 @@ public final class JavaUtilLoggingProvider implements LoggingProvider {
 		StackTraceElement caller = RuntimeProvider.getCallerStackTraceElement(loggerClassName);
 		Logger julLogger = Logger.getLogger(caller.getClassName());
 		java.util.logging.Level julLevel = translate(level);
-		
+
 		if (julLogger.isLoggable(julLevel)) {
 			String message = String.valueOf(obj);
 			if (arguments != null && arguments.length > 0) {
@@ -94,7 +98,7 @@ public final class JavaUtilLoggingProvider implements LoggingProvider {
 
 	/**
 	 * Translates a tinylog severity level into a {@code java.util.logging} level.
-	 * 
+	 *
 	 * @param level
 	 *            Severity level of tinylog
 	 * @return Corresponding level of {@code java.util.logging}
@@ -116,4 +120,7 @@ public final class JavaUtilLoggingProvider implements LoggingProvider {
 		}
 	}
 
+	private static boolean isLoggable(final String callerClassName, final Level level) {
+		return Logger.getLogger(callerClassName).isLoggable(translate(level));
+	}
 }

--- a/tinylog-jul/src/test/java/org/tinylog/adapter/jul/JavaUtilLoggingProviderTest.java
+++ b/tinylog-jul/src/test/java/org/tinylog/adapter/jul/JavaUtilLoggingProviderTest.java
@@ -102,6 +102,19 @@ public final class JavaUtilLoggingProviderTest {
 	}
 
 	/**
+	 * Verifies that {@link Level#INFO}, {@link Level#WARN}, and {@link Level#ERROR} are enabled.
+	 */
+	@Test
+	public void enabledWithLoggerClassName() {
+		JavaUtilLoggingProvider provider = new JavaUtilLoggingProvider();
+
+		String effectualLoggerClass = JavaUtilLoggingProvider.class.getName();
+		assertThat(provider.isEnabled(effectualLoggerClass, null, Level.INFO)).isTrue();
+		assertThat(provider.isEnabled(effectualLoggerClass, null, Level.WARN)).isTrue();
+		assertThat(provider.isEnabled(effectualLoggerClass, null, Level.ERROR)).isTrue();
+	}
+
+	/**
 	 * Verifies that {@link Level#TRACE} and {@link Level#DEBUG} are disabled.
 	 */
 	@Test
@@ -110,6 +123,18 @@ public final class JavaUtilLoggingProviderTest {
 
 		assertThat(provider.isEnabled(1, null, Level.TRACE)).isFalse();
 		assertThat(provider.isEnabled(1, null, Level.DEBUG)).isFalse();
+	}
+
+	/**
+	 * Verifies that {@link Level#TRACE} and {@link Level#DEBUG} are disabled.
+	 */
+	@Test
+	public void disabledWithLoggerClassName() {
+		JavaUtilLoggingProvider provider = new JavaUtilLoggingProvider();
+
+		String effectualLoggerClass = JavaUtilLoggingProvider.class.getName();
+		assertThat(provider.isEnabled(effectualLoggerClass, null, Level.TRACE)).isFalse();
+		assertThat(provider.isEnabled(effectualLoggerClass, null, Level.DEBUG)).isFalse();
 	}
 
 	/**


### PR DESCRIPTION
### Description

Linked issue:

#381  <!-- Related issue from https://github.com/tinylog-org/tinylog/issues -->
