### PR TITLE
Synchronize writing thread with existing writers

### DIFF
--- a/configuration/spotbugs-filters.xml
+++ b/configuration/spotbugs-filters.xml
@@ -87,4 +87,10 @@
 		<!-- Allow writing to static field org.tinylog.policies.DynamicPolicy.reset from instance method org.tinylog.policies.DynamicPolicy.reset -->
 		<Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
 	</Match>
+	<Match>
+		<!-- Writing Thread -->
+		<Class name="org.tinylog.core.WritingThread" />
+		<!-- There is only one writing thread instance to wake up -->
+		<Bug pattern="NO_NOTIFY_NOT_NOTIFYALL" />
+	</Match>
 </FindBugsFilter>


### PR DESCRIPTION
### Description

The writing thread on Android apps can prevent the app from going to sleep as it constantly wakes up every 10ms. I've added synchronisation to wake up only when something is being written. This is critical for our current use case.