### PR TITLE
Add ability to output all keys and values in thread context

### DIFF
--- a/tinylog-impl/src/main/java/org/tinylog/pattern/FormatPatternParser.java
+++ b/tinylog-impl/src/main/java/org/tinylog/pattern/FormatPatternParser.java
@@ -209,13 +209,12 @@ public final class FormatPatternParser {
 	 */
 	private static Token createThreadContextToken(final String configuration) {
 		if (configuration == null) {
-			InternalLogger.log(Level.ERROR, "\"{context}\" requires a key");
-			return new PlainTextToken("");
+			return new ThreadContextToken();
 		} else {
 			int splitIndex = configuration.indexOf(',');
 			String key = splitIndex == -1 ? configuration.trim() : configuration.substring(0, splitIndex).trim();
-			if (key.isEmpty()) {
-				InternalLogger.log(Level.ERROR, "\"{context}\" requires a key");
+			if (key.isEmpty() && splitIndex != -1) {
+				InternalLogger.log(Level.ERROR, "\"{context}\" requires a key if a default value is supplied");
 				return new PlainTextToken("");
 			} else {
 				String defaultValue = splitIndex == -1 ? null : configuration.substring(splitIndex + 1).trim();

--- a/tinylog-impl/src/main/java/org/tinylog/pattern/ThreadContextToken.java
+++ b/tinylog-impl/src/main/java/org/tinylog/pattern/ThreadContextToken.java
@@ -17,6 +17,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 import org.tinylog.core.LogEntry;
 import org.tinylog.core.LogEntryValue;
@@ -28,8 +29,17 @@ final class ThreadContextToken implements Token {
 
 	private static final String DEFAULT_EMPTY_VALUE = "";
 
+	private static final String DELIMITER = ", ";
+
+	private static final String SEPARATOR = "=";
+
 	private final String key;
 	private final String defaultValue;
+
+	ThreadContextToken() {
+		this.key = null;
+		this.defaultValue = DEFAULT_EMPTY_VALUE;
+	}
 
 	/**
 	 * @param key
@@ -58,21 +68,39 @@ final class ThreadContextToken implements Token {
 
 	@Override
 	public void render(final LogEntry logEntry, final StringBuilder builder) {
-		String value = logEntry.getContext().get(key);
-		if (value == null) {
-			builder.append(defaultValue);
+		if (key != null) {
+			String value = logEntry.getContext().get(key);
+			if (value == null) {
+				builder.append(defaultValue);
+			} else {
+				builder.append(value);
+			}
 		} else {
-			builder.append(value);
+			boolean first = true;
+			for (Map.Entry<String, String> contextEntry : logEntry.getContext().entrySet()) {
+				if (first) {
+					first = false;
+				} else {
+					builder.append(DELIMITER);
+				}
+				builder.append(contextEntry.getKey()).append(SEPARATOR).append(contextEntry.getValue());
+			}
 		}
 	}
 
 	@Override
 	public void apply(final LogEntry logEntry, final PreparedStatement statement, final int index) throws SQLException {
-		String value = logEntry.getContext().get(key);
-		if (value == null && !DEFAULT_EMPTY_VALUE.equals(defaultValue)) {
-			statement.setString(index, defaultValue);
+		if (key == null || key.isEmpty()) {
+			StringBuilder builder = new StringBuilder();
+			render(logEntry, builder);
+			statement.setString(index, builder.toString());
 		} else {
-			statement.setString(index, value);
+			String value = logEntry.getContext().get(key);
+			if (value == null && !DEFAULT_EMPTY_VALUE.equals(defaultValue)) {
+				statement.setString(index, defaultValue);
+			} else {
+				statement.setString(index, value);
+			}
 		}
 	}
 

--- a/tinylog-impl/src/main/java/org/tinylog/pattern/ThreadContextToken.java
+++ b/tinylog-impl/src/main/java/org/tinylog/pattern/ThreadContextToken.java
@@ -18,6 +18,7 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.tinylog.core.LogEntry;
 import org.tinylog.core.LogEntryValue;
@@ -76,8 +77,9 @@ final class ThreadContextToken implements Token {
 				builder.append(value);
 			}
 		} else {
+			Map<String, String> sortedContext = new TreeMap<String, String>(logEntry.getContext());
 			boolean first = true;
-			for (Map.Entry<String, String> contextEntry : logEntry.getContext().entrySet()) {
+			for (Map.Entry<String, String> contextEntry : sortedContext.entrySet()) {
 				if (first) {
 					first = false;
 				} else {

--- a/tinylog-impl/src/test/java/org/tinylog/pattern/FormatPatternParserTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/pattern/FormatPatternParserTest.java
@@ -172,11 +172,11 @@ public final class FormatPatternParserTest {
 	 * Verifies that {@code {context}} without a defined key will output all keys and their values.
 	 */
 	@Test
-	public void contextMissingKey() {
+	public void contextWithoutKey() {
 		assertThat(render("context", LogEntryBuilder.empty().create())).isEmpty();
 		assertThat(render("context", LogEntryBuilder.empty().context("pi", "3.14").create())).isEqualTo("pi=3.14");
 		assertThat(render("context", LogEntryBuilder.empty().context("pi", "3.14").context("e", "2.72").create()))
-			.isIn("pi=3.14, e=2.72", "e=2.72, pi=3.14");
+			.isEqualTo("e=2.72, pi=3.14");
 	}
 
 	/**

--- a/tinylog-impl/src/test/java/org/tinylog/pattern/FormatPatternParserTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/pattern/FormatPatternParserTest.java
@@ -169,12 +169,14 @@ public final class FormatPatternParserTest {
 	}
 
 	/**
-	 * Verifies that {@code {context}} without a defined key will produce an error.
+	 * Verifies that {@code {context}} without a defined key will output all keys and their values.
 	 */
 	@Test
 	public void contextMissingKey() {
 		assertThat(render("context", LogEntryBuilder.empty().create())).isEmpty();
-		assertThat(systemStream.consumeErrorOutput()).containsOnlyOnce("ERROR").containsOnlyOnce("context");
+		assertThat(render("context", LogEntryBuilder.empty().context("pi", "3.14").create())).isEqualTo("pi=3.14");
+		assertThat(render("context", LogEntryBuilder.empty().context("pi", "3.14").context("e", "2.72").create()))
+			.isIn("pi=3.14, e=2.72", "e=2.72, pi=3.14");
 	}
 
 	/**

--- a/tinylog-impl/src/test/java/org/tinylog/pattern/ThreadContextTokenTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/pattern/ThreadContextTokenTest.java
@@ -15,6 +15,7 @@ package org.tinylog.pattern;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
@@ -116,6 +117,39 @@ public final class ThreadContextTokenTest {
 		PreparedStatement statement = mock(PreparedStatement.class);
 		token.apply(createLogEntry(singletonMap("test", "42")), statement, 1);
 		verify(statement).setString(1, "42");
+	}
+
+	/**
+	 * Verifies that all properties will be rendered for a {@link StringBuilder} if the token has no key.
+	 */
+	@Test
+	public void renderAllProperties() {
+		ThreadContextToken token = new ThreadContextToken();
+
+		Map<String, String> context = new HashMap<>(2);
+		context.put("test", "42");
+		context.put("sample", "11");
+
+		assertThat(render(token, context)).isEqualTo("sample=11, test=42");
+	}
+
+	/**
+	 * Verifies that all properties in a thread context will be added to a {@link PreparedStatement}, if the token has no key.
+	 *
+	 * @throws SQLException
+	 *             Failed to add value ot prepared SQL statement
+	 */
+	@Test
+	public void applyAllProperties() throws SQLException {
+		ThreadContextToken token = new ThreadContextToken();
+
+		Map<String, String> context = new HashMap<>(2);
+		context.put("test", "42");
+		context.put("sample", "11");
+
+		PreparedStatement statement = mock(PreparedStatement.class);
+		token.apply(createLogEntry(context), statement, 1);
+		verify(statement).setString(1, "sample=11, test=42");
 	}
 
 	/**


### PR DESCRIPTION
### Description

The keys in a thread context can differ for different code paths. It would be good if one could log whatever keys and values exist in the thread context without specifying all possible keys in the logging configuration.

This change modifies the `context` placeholder so that it can be used without specifying a key. When no key is specified, all keys and their values are sent to the output.


Linked website pull request, if the documention of https://tinylog.org/v2/ has to be updated:

tinylog-org/website#188 

### Definition of Done

- [X] I read [contributing.md](https://github.com/tinylog-org/tinylog/blob/v2.7/contributing.md)
- [X] There are no TODOs left in the code
- [X] Code style follows the tinylog standard
- [X] All classes and methods have Javadoc
- [X] Changes are covered by JUnit tests including edge cases, errors, and exception handling
- [X] Maven build works including compiling, tests, and checks (`mvn verify`)
- [X] Changes are committed by a verified email address that is assigned to the GitHub account (https://github.com/settings/emails)
- [X] Documentation on the [tinylog website](https://tinylog.org/v2/) is up-to-date or updated by a pull request to the repository [tinylog-org/website](https://github.com/tinylog-org/website)

### Agreements

- [X] I agree that my changes will be published under the terms of the [Apache License 2.0](https://github.com/tinylog-org/tinylog/blob/v2.0/license.txt) (mandatory)
- [X] I agree that my GitHub user name will be published in the release notes (optional)
