### PR TITLE
Make DynamicPathTest pass on any machine

### DIFF
--- a/tinylog-impl/src/test/java/org/tinylog/impl/path/DynamicPathTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/impl/path/DynamicPathTest.java
@@ -17,7 +17,7 @@ import org.tinylog.core.test.log.TestClock;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@CaptureLogEntries
+@CaptureLogEntries(configuration = "zone=UTC")
 class DynamicPathTest {
 
     @TempDir


### PR DESCRIPTION
### Description

On my machine, I see a unit test failure when `DynamicPathTest` runs. The error message is

```
DynamicPathTest$GeneratingNewPath.generateDynamicPath:124 expected: /tmp/junit1072668570111541721/1970-01-01.log
 but was: /tmp/junit1072668570111541721/1969-12-31.log
```

The test generates a filename using a date string in the format `yyyy-MM-dd`. The value for the date comes from a clock object set to `Instant.EPOCH`, which is defined as midnight on 1970-01-01 in UTC. But before being formatted for output, the date value is converted to a `ZonedDateTime`. (See `DynamicPath#generateNewPath`.) The zone id is set to the system default, which on my machine is "America/New_York." In that time zone, `Instant.EPOCH` falls on 1969-12-31. The formatter thus outputs "1969-12-31," which doesn't match the expected filename, "1970-01-01." So the unit test fails.

This change explicitly sets the zone id used for the `ZonedDateTime` to UTC instead of whatever the system default zone id is. This makes the generated filename predictably come out as "1970-01-01," so the unit test will always pass.

### Definition of Done

- [x] I read [contributing.md](https://github.com/tinylog-org/tinylog/blob/v2.8/contributing.md)
- [x] There are no TODOs left in the code
- [x] Code style follows the tinylog standard
- [x] All classes and methods have Javadoc
- [x] Changes are covered by JUnit tests including edge cases, errors, and exception handling
- [x] Maven build works including compiling, tests, and checks (`mvn verify`)
- [x] Changes are committed by a verified email address that is assigned to the GitHub account (https://github.com/settings/emails)
- [x] Documentation on the [tinylog website](https://tinylog.org/v2/) is up-to-date or updated by a pull request to the repository [tinylog-org/website](https://github.com/tinylog-org/website)

### Agreements

- [x] I agree that my changes will be published under the terms of the [Apache License 2.0](https://github.com/tinylog-org/tinylog/blob/v2.0/license.txt) (mandatory)
- [x] I agree that my GitHub user name will be published in the release notes (optional)
