### PR TITLE
Suggesting improve initialization performance

### DIFF
--- a/tinylog-api/src/main/java/org/tinylog/runtime/LegacyJavaRuntime.java
+++ b/tinylog-api/src/main/java/org/tinylog/runtime/LegacyJavaRuntime.java
@@ -27,7 +27,7 @@ import org.tinylog.provider.InternalLogger;
  */
 public final class LegacyJavaRuntime extends AbstractJavaRuntime {
 
-	private static final Timestamp startTime = new LegacyTimestamp(ManagementFactory.getRuntimeMXBean().getStartTime());
+	private static final Timestamp startTime = new LegacyTimestamp(System.currentTimeMillis());
 
 	private final boolean hasSunReflection;
 	private final Method stackTraceElementGetter;

--- a/tinylog-api/src/main/java/org/tinylog/runtime/ModernJavaRuntime.java
+++ b/tinylog-api/src/main/java/org/tinylog/runtime/ModernJavaRuntime.java
@@ -95,6 +95,7 @@ final class ModernJavaRuntime extends AbstractJavaRuntime {
 	 *
 	 * @return Process handle of current process
 	 */
+	@IgnoreJRERequirement
 	private static ProcessHandle getCurrentProcess() {
 		try {
 			return ProcessHandle.current();
@@ -105,10 +106,10 @@ final class ModernJavaRuntime extends AbstractJavaRuntime {
 	}
 
 	@IgnoreJRERequirement
-	private static class ClassNameExtractorByDepth implements Function<Stream<StackFrame>, String> {
+	private static final class ClassNameExtractorByDepth implements Function<Stream<StackFrame>, String> {
 		private final int depth;
 
-		private ClassNameExtractorByDepth(int depth) {
+		private ClassNameExtractorByDepth(final int depth) {
 			this.depth = depth;
 		}
 
@@ -118,7 +119,7 @@ final class ModernJavaRuntime extends AbstractJavaRuntime {
 					.findFirst()
 					.map(new Function<StackFrame, String>() {
 						@Override
-						public String apply(StackFrame stackFrame) {
+						public String apply(final StackFrame stackFrame) {
 							return stackFrame.getClassName();
 						}
 					})
@@ -130,7 +131,7 @@ final class ModernJavaRuntime extends AbstractJavaRuntime {
 	private static final class ClassNameExtractorByLoggerClassName implements Function<Stream<StackFrame>, String> {
 		private final String loggerClassName;
 
-		private ClassNameExtractorByLoggerClassName(String loggerClassName) {
+		private ClassNameExtractorByLoggerClassName(final String loggerClassName) {
 			this.loggerClassName = loggerClassName;
 		}
 

--- a/tinylog-api/src/main/java/org/tinylog/runtime/ModernJavaRuntime.java
+++ b/tinylog-api/src/main/java/org/tinylog/runtime/ModernJavaRuntime.java
@@ -14,7 +14,6 @@
 package org.tinylog.runtime;
 
 import java.lang.StackWalker.StackFrame;
-import java.lang.management.ManagementFactory;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.function.Function;
@@ -31,8 +30,8 @@ import org.tinylog.provider.InternalLogger;
 final class ModernJavaRuntime extends AbstractJavaRuntime {
 
 	private static final Timestamp startTime = new PreciseTimestamp(
-		ManagementFactory.getRuntimeMXBean().getStartTime(),
-		0
+			System.currentTimeMillis(),
+			0
 	);
 
 	private final ProcessHandle currentProcess = getCurrentProcess();

--- a/tinylog-api/src/main/java/org/tinylog/runtime/ModernJavaRuntime.java
+++ b/tinylog-api/src/main/java/org/tinylog/runtime/ModernJavaRuntime.java
@@ -57,6 +57,7 @@ final class ModernJavaRuntime extends AbstractJavaRuntime {
 	}
 
 	@Override
+	@IgnoreJRERequirement
 	public String getCallerClassName(final int depth) {
 		StackWalker walker = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
 		return walker.walk(new Function<Stream<StackFrame>, String>() {
@@ -76,6 +77,7 @@ final class ModernJavaRuntime extends AbstractJavaRuntime {
 	}
 
 	@Override
+	@IgnoreJRERequirement
 	public String getCallerClassName(final String loggerClassName) {
 		return StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).walk(new Function<Stream<StackFrame>, String>() {
 			@Override

--- a/tinylog-api/src/main/java/org/tinylog/runtime/ModernJavaRuntime.java
+++ b/tinylog-api/src/main/java/org/tinylog/runtime/ModernJavaRuntime.java
@@ -104,8 +104,8 @@ final class ModernJavaRuntime extends AbstractJavaRuntime {
 	 */
 	private static ProcessHandle getCurrentProcess() {
 		try {
-			return (ProcessHandle) ProcessHandle.class.getDeclaredMethod("current").invoke(null);
-		} catch (ReflectiveOperationException ex) {
+			return ProcessHandle.current();
+		} catch (SecurityException ex) {
 			InternalLogger.log(Level.ERROR, ex, "Failed to receive the handle of the current process");
 			return null;
 		}

--- a/tinylog-api/src/main/java/org/tinylog/runtime/ModernJavaRuntime.java
+++ b/tinylog-api/src/main/java/org/tinylog/runtime/ModernJavaRuntime.java
@@ -117,12 +117,7 @@ final class ModernJavaRuntime extends AbstractJavaRuntime {
 		public String apply(final Stream<StackFrame> frames) {
 			return frames.skip(depth)
 					.findFirst()
-					.map(new Function<StackFrame, String>() {
-						@Override
-						public String apply(final StackFrame stackFrame) {
-							return stackFrame.getClassName();
-						}
-					})
+					.map(new ClassNameMapper())
 					.orElse(null);
 		}
 	}
@@ -137,18 +132,30 @@ final class ModernJavaRuntime extends AbstractJavaRuntime {
 
 		@Override
 		public String apply(final Stream<StackFrame> stream) {
-			return stream.map(new Function<StackFrame, String>() {
-				@Override
-				public String apply(final StackFrame stackFrame) {
-					return stackFrame.getClassName();
-				}
-			}).dropWhile(new Predicate<String>() {
+			return stream.map(new ClassNameMapper()).dropWhile(new Predicate<String>() {
 				@Override
 				public boolean test(final String name) {
 					return !name.equals(loggerClassName);
 				}
 			}).skip(1).findFirst().orElse(null);
 		}
+	}
+
+	/**
+	 * Mapper for getting the class name from a {@link StackFrame}.
+	 */
+	@IgnoreJRERequirement
+	private static final class ClassNameMapper implements Function<StackFrame, String> {
+
+		/** */
+		private ClassNameMapper() {
+		}
+
+		@Override
+		public String apply(final StackFrame stackFrame) {
+			return stackFrame.getClassName();
+		}
+
 	}
 
 	/**


### PR DESCRIPTION
### Description

I was happy to see that there are logging libraries in java that don't need multiple 100s of milliseconds just for initialization.

Here I made some suggestions to reduces the tinylogs init performance further by ~10ms
- Replace `ClassContextSecurityManager()` with `StackWalker`
- Use direct call instead of reflection in `getCurrentProcess` (unsure why it uses reflection here)
- Use `System.currentTimeMillis()` instead of JVM start time. Really unsure if this would be acceptable but this save about 5ms it think.   

### Agreements

- [x] I agree that my changes will be published under the terms of the [Apache License 2.0](https://github.com/tinylog-org/tinylog/blob/v2.0/license.txt) (mandatory)
- [x] I agree that my GitHub user name will be published in the release notes (optional)
