### PR TITLE
fix CVE-2022-24329 vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 		<build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
 		<maven-resources-plugin.version>3.4.0</maven-resources-plugin.version>
 		<maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-		<kotlin-maven-plugin.version>1.6.21</kotlin-maven-plugin.version>
+		<kotlin-maven-plugin.version>1.7.22</kotlin-maven-plugin.version>
 		<scala-maven-plugin.version>4.9.9</scala-maven-plugin.version>
 		<animal-sniffer-maven-plugin.version>1.27</animal-sniffer-maven-plugin.version>
 		<jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
@@ -88,7 +88,7 @@
 		<jboss-logging.version>3.4.3.Final</jboss-logging.version>
 		<jmh.version>1.37</jmh.version>
 		<junit.version>4.13.2</junit.version>
-		<kotlin.version>1.4.32</kotlin.version>
+		<kotlin.version>1.6.21</kotlin.version>
 		<lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
 		<mockk.version>1.12.4</mockk.version>
 		<powermock.version>2.0.9</powermock.version>
@@ -139,7 +139,7 @@
 			<properties>
 				<!-- Real Java versions for clean release build -->
 				<maven.compiler.source>1.6</maven.compiler.source>
-				<maven.compiler.target>1.6</maven.compiler.target>
+				<maven.compiler.target>1.8</maven.compiler.target>
 				<maven.compiler.testSource>9</maven.compiler.testSource>
 				<maven.compiler.testTarget>9</maven.compiler.testTarget>
 				<!-- Enable Animal Sniffer for release builds -->


### PR DESCRIPTION
### Description
Fixed vulnerabilities [CVE-2022-24329](https://www.cve.org/CVERecord?id=CVE-2022-24329) in Kotlin < 1.6 according to the [mvnrepository](https://mvnrepository.com/artifact/org.tinylog/tinylog-api-kotlin/2.8.0-M1).

### Definition of Done

- [x] I read [contributing.md](https://github.com/tinylog-org/tinylog/blob/v2.8/contributing.md)
- [x] There are no TODOs left in the code
- [x] Code style follows the tinylog standard
- [x] All classes and methods have Javadoc
- [x] Changes are covered by JUnit tests including edge cases, errors, and exception handling
- [x] Maven build works including compiling, tests, and checks (`mvn verify`)
- [x] Changes are committed by a verified email address that is assigned to the GitHub account (https://github.com/settings/emails)
- [x] Documentation on the [tinylog website](https://tinylog.org/v2/) is up-to-date or updated by a pull request to the repository [tinylog-org/website](https://github.com/tinylog-org/website)

### Agreements

- [x] I agree that my changes will be published under the terms of the [Apache License 2.0](https://github.com/tinylog-org/tinylog/blob/v2.0/license.txt) (mandatory)
- [x] I agree that my GitHub user name will be published in the release notes (optional)
