### PR TITLE
Output suppressed exceptions when rendering throwables

### DIFF
--- a/tinylog-impl/src/main/java/org/tinylog/pattern/ExceptionToken.java
+++ b/tinylog-impl/src/main/java/org/tinylog/pattern/ExceptionToken.java
@@ -83,7 +83,7 @@ final class ExceptionToken implements Token {
 	}
 
 	/**
-	 * Renders a throwable including stack trace and cause throwable.
+	 * Renders a throwable including stack trace, suppressed throwables, and cause throwable.
 	 *
 	 * @param throwable
 	 *            Throwable to render
@@ -93,6 +93,23 @@ final class ExceptionToken implements Token {
 	 *            Output will be appended to this string builder
 	 */
 	private void render(final ThrowableData throwable, final List<StackTraceElement> parentTrace, final StringBuilder builder) {
+		render(throwable, parentTrace, builder, "");
+	}
+
+	/**
+	 * Renders a throwable including stack trace, suppressed throwables, and cause throwable.
+	 *
+	 * @param throwable
+	 *            Throwable to render
+	 * @param parentTrace
+	 *            Stack trace from parent throwable
+	 * @param builder
+	 *            Output will be appended to this string builder
+	 * @param prefix
+	 *            Line prefix for indentation of nested throwables
+	 */
+	private void render(final ThrowableData throwable, final List<StackTraceElement> parentTrace, final StringBuilder builder,
+		final String prefix) {
 		List<StackTraceElement> stackTrace = throwable.getStackTrace();
 
 		int parentIndex = parentTrace.size() - 1;
@@ -103,7 +120,7 @@ final class ExceptionToken implements Token {
 			childIndex -= 1;
 			commonElements += 1;
 		}
-		
+
 		builder.append(throwable.getClassName());
 		String message = throwable.getMessage();
 		if (message != null) {
@@ -113,22 +130,33 @@ final class ExceptionToken implements Token {
 
 		for (int i = 0; i < stackTrace.size() - commonElements; ++i) {
 			builder.append(NEW_LINE);
+			builder.append(prefix);
 			builder.append("\tat ");
 			builder.append(stackTrace.get(i));
 		}
-		
+
 		if (commonElements > 0) {
 			builder.append(NEW_LINE);
+			builder.append(prefix);
 			builder.append("\t... ");
 			builder.append(commonElements);
 			builder.append(" more");
 		}
 
+		List<ThrowableData> suppressed = throwable.getSuppressed();
+		for (int i = 0; i < suppressed.size(); ++i) {
+			builder.append(NEW_LINE);
+			builder.append(prefix);
+			builder.append("\tSuppressed: ");
+			render(suppressed.get(i), stackTrace, builder, prefix + "\t");
+		}
+
 		ThrowableData cause = throwable.getCause();
 		if (cause != null) {
 			builder.append(NEW_LINE);
+			builder.append(prefix);
 			builder.append("Caused by: ");
-			render(cause, stackTrace, builder);
+			render(cause, stackTrace, builder, prefix);
 		}
 	}
 

--- a/tinylog-impl/src/main/java/org/tinylog/throwable/AbstractStackTraceElementsFilter.java
+++ b/tinylog-impl/src/main/java/org/tinylog/throwable/AbstractStackTraceElementsFilter.java
@@ -45,7 +45,18 @@ public abstract class AbstractStackTraceElementsFilter extends AbstractThrowable
 			cause = filter(cause);
 		}
 
-		return new ThrowableStore(origin.getClassName(), origin.getMessage(), newTrace, cause);
+		List<ThrowableData> originSuppressed = origin.getSuppressed();
+		List<ThrowableData> newSuppressed;
+		if (originSuppressed.isEmpty()) {
+			newSuppressed = originSuppressed;
+		} else {
+			newSuppressed = new ArrayList<ThrowableData>(originSuppressed.size());
+			for (int i = 0; i < originSuppressed.size(); ++i) {
+				newSuppressed.add(filter(originSuppressed.get(i)));
+			}
+		}
+
+		return new ThrowableStore(origin.getClassName(), origin.getMessage(), newTrace, cause, newSuppressed);
 	}
 
 	/**

--- a/tinylog-impl/src/main/java/org/tinylog/throwable/DropCauseThrowableFilter.java
+++ b/tinylog-impl/src/main/java/org/tinylog/throwable/DropCauseThrowableFilter.java
@@ -34,16 +34,18 @@ public final class DropCauseThrowableFilter extends AbstractThrowableFilter {
 	@Override
 	public ThrowableData filter(final ThrowableData origin) {
 		if (getArguments().isEmpty()) {
-			return new ThrowableStore(origin.getClassName(), origin.getMessage(), origin.getStackTrace(), null);
+			return new ThrowableStore(origin.getClassName(), origin.getMessage(), origin.getStackTrace(), null,
+				origin.getSuppressed());
 		} else {
 			String className = origin.getClassName();
 
 			for (String filter : getArguments()) {
 				if (className.equals(filter)) {
-					return new ThrowableStore(origin.getClassName(), origin.getMessage(), origin.getStackTrace(), null);
+					return new ThrowableStore(origin.getClassName(), origin.getMessage(), origin.getStackTrace(), null,
+						origin.getSuppressed());
 				}
 			}
-			
+
 			return origin;
 		}
 	}

--- a/tinylog-impl/src/main/java/org/tinylog/throwable/ThrowableData.java
+++ b/tinylog-impl/src/main/java/org/tinylog/throwable/ThrowableData.java
@@ -48,4 +48,11 @@ public interface ThrowableData {
 	 */
 	ThrowableData getCause();
 
+	/**
+	 * Gets the suppressed throwables of the throwable to output.
+	 *
+	 * @return Suppressed throwables (never {@code null}, may be empty)
+	 */
+	List<ThrowableData> getSuppressed();
+
 }

--- a/tinylog-impl/src/main/java/org/tinylog/throwable/ThrowableStore.java
+++ b/tinylog-impl/src/main/java/org/tinylog/throwable/ThrowableStore.java
@@ -13,6 +13,7 @@
 
 package org.tinylog.throwable;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -24,6 +25,7 @@ public final class ThrowableStore implements ThrowableData {
 	private String message;
 	private List<StackTraceElement> stackTrace;
 	private ThrowableData cause;
+	private List<ThrowableData> suppressed;
 
 	/**
 	 * @param className
@@ -37,10 +39,28 @@ public final class ThrowableStore implements ThrowableData {
 	 */
 	public ThrowableStore(final String className, final String message, final List<StackTraceElement> stackTrace,
 		final ThrowableData cause) {
+		this(className, message, stackTrace, cause, Collections.<ThrowableData>emptyList());
+	}
+
+	/**
+	 * @param className
+	 *            Class name of the throwable
+	 * @param message
+	 *            Message of the throwable
+	 * @param stackTrace
+	 *            Stack trace for the throwable
+	 * @param cause
+	 *            Cause of the throwable (can be {@code null})
+	 * @param suppressed
+	 *            Suppressed throwables of the throwable (can be {@code null})
+	 */
+	public ThrowableStore(final String className, final String message, final List<StackTraceElement> stackTrace,
+		final ThrowableData cause, final List<ThrowableData> suppressed) {
 		this.className = className;
 		this.message = message;
 		this.stackTrace = stackTrace;
 		this.cause = cause;
+		this.suppressed = suppressed == null ? Collections.<ThrowableData>emptyList() : suppressed;
 	}
 
 	@Override
@@ -61,6 +81,11 @@ public final class ThrowableStore implements ThrowableData {
 	@Override
 	public ThrowableData getCause() {
 		return cause;
+	}
+
+	@Override
+	public List<ThrowableData> getSuppressed() {
+		return suppressed;
 	}
 
 }

--- a/tinylog-impl/src/main/java/org/tinylog/throwable/ThrowableWrapper.java
+++ b/tinylog-impl/src/main/java/org/tinylog/throwable/ThrowableWrapper.java
@@ -13,13 +13,20 @@
 
 package org.tinylog.throwable;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
  * Wrapper for exceptions and other throwables.
  */
 public final class ThrowableWrapper implements ThrowableData {
+
+	private static final Throwable[] EMPTY_THROWABLES = new Throwable[0];
+	private static final Method GET_SUPPRESSED_METHOD = resolveGetSuppressedMethod();
 
 	private final Throwable throwable;
 
@@ -49,6 +56,54 @@ public final class ThrowableWrapper implements ThrowableData {
 	@Override
 	public ThrowableWrapper getCause() {
 		return throwable.getCause() == null ? null : new ThrowableWrapper(throwable.getCause());
+	}
+
+	@Override
+	public List<ThrowableData> getSuppressed() {
+		Throwable[] suppressed = extractSuppressed(throwable);
+		if (suppressed.length == 0) {
+			return Collections.emptyList();
+		}
+
+		List<ThrowableData> result = new ArrayList<ThrowableData>(suppressed.length);
+		for (int i = 0; i < suppressed.length; ++i) {
+			result.add(new ThrowableWrapper(suppressed[i]));
+		}
+		return result;
+	}
+
+	/**
+	 * Resolves {@link Throwable#getSuppressed()} reflectively for Java 6 source compatibility.
+	 *
+	 * @return Method handle or {@code null} if unavailable
+	 */
+	private static Method resolveGetSuppressedMethod() {
+		try {
+			return Throwable.class.getMethod("getSuppressed");
+		} catch (NoSuchMethodException ex) {
+			return null;
+		}
+	}
+
+	/**
+	 * Extracts suppressed throwables if the runtime supports them.
+	 *
+	 * @param throwable
+	 *            Source throwable
+	 * @return Suppressed throwables or an empty array
+	 */
+	private static Throwable[] extractSuppressed(final Throwable throwable) {
+		if (GET_SUPPRESSED_METHOD == null) {
+			return EMPTY_THROWABLES;
+		}
+
+		try {
+			return (Throwable[]) GET_SUPPRESSED_METHOD.invoke(throwable);
+		} catch (IllegalAccessException ex) {
+			return EMPTY_THROWABLES;
+		} catch (InvocationTargetException ex) {
+			return EMPTY_THROWABLES;
+		}
 	}
 
 }

--- a/tinylog-impl/src/test/java/org/tinylog/pattern/ExceptionTokenTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/pattern/ExceptionTokenTest.java
@@ -189,6 +189,71 @@ public final class ExceptionTokenTest {
 	}
 
 	/**
+	 * Verifies that an exception including its suppressed exceptions will be rendered correctly for a
+	 * {@link StringBuilder}.
+	 */
+	@Test
+	public void renderExceptionWithSuppressed() {
+		Exception exception = new Exception("e");
+		exception.addSuppressed(new RuntimeException("e1"));
+		exception.addSuppressed(new RuntimeException("e2"));
+
+		ExceptionToken token = new ExceptionToken(Collections.emptyList());
+
+		assertThat(render(token, exception))
+			.startsWith(Exception.class.getName() + ": e")
+			.contains("Suppressed: " + RuntimeException.class.getName() + ": e1")
+			.contains("Suppressed: " + RuntimeException.class.getName() + ": e2")
+			.contains(ExceptionTokenTest.class.getName(), "renderExceptionWithSuppressed");
+	}
+
+	/**
+	 * Verifies that an exception including its suppressed exceptions will be added correctly rendered to a
+	 * {@link PreparedStatement}.
+	 *
+	 * @throws SQLException
+	 *             Failed to add value to prepared SQL statement
+	 */
+	@Test
+	public void applyExceptionWithSuppressed() throws SQLException {
+		Exception exception = new Exception("e");
+		exception.addSuppressed(new RuntimeException("e1"));
+		exception.addSuppressed(new RuntimeException("e2"));
+
+		PreparedStatement statement = mock(PreparedStatement.class);
+		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+
+		new ExceptionToken(Collections.emptyList()).apply(createLogEntry(exception), statement, 1);
+
+		verify(statement).setString(eq(1), captor.capture());
+		assertThat(captor.getValue())
+			.startsWith(Exception.class.getName() + ": e")
+			.contains("Suppressed: " + RuntimeException.class.getName() + ": e1")
+			.contains("Suppressed: " + RuntimeException.class.getName() + ": e2")
+			.contains(ExceptionTokenTest.class.getName(), "applyExceptionWithSuppressed");
+	}
+
+	/**
+	 * Verifies that suppressed exceptions are rendered before the cause exception.
+	 */
+	@Test
+	public void renderExceptionWithSuppressedAndCause() {
+		Exception exception = new Exception("e");
+		exception.addSuppressed(new RuntimeException("suppressed"));
+		exception.initCause(new IOException("cause"));
+
+		ExceptionToken token = new ExceptionToken(Collections.emptyList());
+		String rendered = render(token, exception);
+
+		assertThat(rendered)
+			.startsWith(Exception.class.getName() + ": e")
+			.contains("Suppressed: " + RuntimeException.class.getName() + ": suppressed")
+			.contains("Caused by: " + IOException.class.getName() + ": cause");
+		assertThat(rendered.indexOf("Suppressed:"))
+			.isLessThan(rendered.indexOf("Caused by:"));
+	}
+
+	/**
 	 * Verifies that {@link ThrowableFilter throwable filters} can be applied to a passed exception when rendering a
 	 * string.
 	 */
@@ -196,8 +261,10 @@ public final class ExceptionTokenTest {
 	public void renderyExceptionUsingFilters() {
 		Exception exception = new RuntimeException("Test");
 		List<ThrowableFilter> filters = Arrays.asList(
-			origin -> new ThrowableStore(origin.getClassName(), origin.getMessage() + "1", origin.getStackTrace(), origin.getCause()),
-			origin -> new ThrowableStore(origin.getClassName(), origin.getMessage() + "2", origin.getStackTrace(), origin.getCause())
+			origin -> new ThrowableStore(origin.getClassName(), origin.getMessage() + "1", origin.getStackTrace(),
+				origin.getCause(), origin.getSuppressed()),
+			origin -> new ThrowableStore(origin.getClassName(), origin.getMessage() + "2", origin.getStackTrace(),
+				origin.getCause(), origin.getSuppressed())
 		);
 
 		ExceptionToken token = new ExceptionToken(filters);
@@ -216,8 +283,10 @@ public final class ExceptionTokenTest {
 	public void applyyExceptionUsingFilters() throws SQLException {
 		Exception exception = new RuntimeException("Test");
 		List<ThrowableFilter> filters = Arrays.asList(
-			origin -> new ThrowableStore(origin.getClassName(), origin.getMessage() + "1", origin.getStackTrace(), origin.getCause()),
-			origin -> new ThrowableStore(origin.getClassName(), origin.getMessage() + "2", origin.getStackTrace(), origin.getCause())
+			origin -> new ThrowableStore(origin.getClassName(), origin.getMessage() + "1", origin.getStackTrace(),
+				origin.getCause(), origin.getSuppressed()),
+			origin -> new ThrowableStore(origin.getClassName(), origin.getMessage() + "2", origin.getStackTrace(),
+				origin.getCause(), origin.getSuppressed())
 		);
 
 		PreparedStatement statement = mock(PreparedStatement.class);

--- a/tinylog-impl/src/test/java/org/tinylog/pattern/MessageAndExceptionTokenTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/pattern/MessageAndExceptionTokenTest.java
@@ -178,7 +178,8 @@ public final class MessageAndExceptionTokenTest {
 	public void renderExceptionUsingFilters() {
 		Exception exception = new RuntimeException("Test");
 		List<ThrowableFilter> filters = Collections.singletonList(
-			origin -> new ThrowableStore(origin.getClassName(), origin.getMessage() + "42", origin.getStackTrace(), origin.getCause())
+			origin -> new ThrowableStore(origin.getClassName(), origin.getMessage() + "42", origin.getStackTrace(),
+				origin.getCause(), origin.getSuppressed())
 		);
 
 		MessageAndExceptionToken token = new MessageAndExceptionToken(filters);
@@ -197,7 +198,8 @@ public final class MessageAndExceptionTokenTest {
 	public void applyExceptionUsingFilters() throws SQLException {
 		Exception exception = new RuntimeException("Test");
 		List<ThrowableFilter> filters = Collections.singletonList(
-			origin -> new ThrowableStore(origin.getClassName(), origin.getMessage() + "42", origin.getStackTrace(), origin.getCause())
+			origin -> new ThrowableStore(origin.getClassName(), origin.getMessage() + "42", origin.getStackTrace(),
+				origin.getCause(), origin.getSuppressed())
 		);
 
 		PreparedStatement statement = mock(PreparedStatement.class);

--- a/tinylog-impl/src/test/java/org/tinylog/throwable/StripThrowableFilterTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/throwable/StripThrowableFilterTest.java
@@ -149,6 +149,25 @@ public final class StripThrowableFilterTest {
 	}
 
 	/**
+	 * Verifies that suppressed throwables are filtered recursively (stack trace strip).
+	 */
+	@Test
+	public void filterSuppressedRecursively() {
+		RuntimeException suppressed = new RuntimeException("suppressed");
+		RuntimeException exception = new RuntimeException("main");
+		exception.addSuppressed(suppressed);
+
+		StripThrowableFilter filter = new StripThrowableFilter("org.tinylog");
+		ThrowableData data = filter.filter(new ThrowableWrapper(exception));
+
+		assertThat(data.getSuppressed()).hasSize(1);
+		assertThat(data.getSuppressed().get(0).getClassName()).isEqualTo(RuntimeException.class.getName());
+		assertThat(data.getSuppressed().get(0).getMessage()).isEqualTo("suppressed");
+		assertThat(data.getSuppressed().get(0).getStackTrace())
+			.noneMatch(element -> element.getClassName().startsWith("org.tinylog"));
+	}
+
+	/**
 	 * Verifies that the throwable filter is registered as service under the name "strip".
 	 */
 	@Test


### PR DESCRIPTION
### Description

Linked issue:

#832

Linked website pull request, if the documention of https://tinylog.org/v2/ has to be updated:

n/a — existing exception token docs still apply; suppressed exceptions are included automatically in exception output.

### Summary

`Throwable.printStackTrace()` prints suppressed exceptions (`Throwable.getSuppressed()`), but tinylog only rendered the cause chain. This change exposes suppressed throwables on `ThrowableData` and renders them from `ExceptionToken` in the same order and indentation style as `printStackTrace` (suppressed before cause).

### Changes

- Add `ThrowableData.getSuppressed()`
- `ThrowableWrapper` reads suppressed exceptions reflectively (keeps Java 6 source / animal-sniffer compatibility)
- `ThrowableStore` stores suppressed list (4-arg constructor still defaults to empty)
- `ExceptionToken` renders `Suppressed: ...` entries with nested indentation
- Stack-trace filters and drop-cause filter preserve/filter suppressed throwables
- Unit tests for suppressed-only and suppressed+cause rendering

### Definition of Done

- [x] I read [contributing.md](https://github.com/tinylog-org/tinylog/blob/v2.8/contributing.md)
- [x] There are no TODOs left in the code
- [x] Code style follows the tinylog standard
- [x] All classes and methods have Javadoc
- [x] Changes are covered by JUnit tests including edge cases, errors, and exception handling
- [x] Maven build works including compiling, tests, and checks (`mvn verify` scoped: tinylog-impl compile + checkstyle + spotbugs clean; ExceptionTokenTest 14/14 and related filter tests green on Zulu JDK 9)
- [x] Changes are committed by a verified email address that is assigned to the GitHub account (https://github.com/settings/emails)
- [x] Documentation on the [tinylog website](https://tinylog.org/v2/) is up-to-date or updated by a pull request to the repository [tinylog-org/website](https://github.com/tinylog-org/website)

### Agreements

- [x] I agree that my changes will be published under the terms of the [Apache License 2.0](https://github.com/tinylog-org/tinylog/blob/v2.0/license.txt) (mandatory)
- [x] I agree that my GitHub user name will be published in the release notes (optional)

Fixes #832