### PR TITLE
Flush console streams to preserve log order

### DIFF
--- a/tinylog-impl/src/main/java/org/tinylog/writers/ConsoleWriter.java
+++ b/tinylog-impl/src/main/java/org/tinylog/writers/ConsoleWriter.java
@@ -85,15 +85,20 @@ public final class ConsoleWriter extends AbstractFormatPatternWriter {
 
 	@Override
 	public void write(final LogEntry logEntry) {
+		String rendered = render(logEntry);
 		if (logEntry.getLevel().ordinal() < errorLevel.ordinal()) {
-			System.out.print(render(logEntry));
+			System.out.print(rendered);
+			System.out.flush();
 		} else {
-			System.err.print(render(logEntry));
+			System.err.print(rendered);
+			System.err.flush();
 		}
 	}
 
 	@Override
 	public void flush() {
+		System.out.flush();
+		System.err.flush();
 	}
 
 	@Override

--- a/tinylog-impl/src/test/java/org/tinylog/writers/ConsoleWriterTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/writers/ConsoleWriterTest.java
@@ -13,7 +13,8 @@
 
 package org.tinylog.writers;
 
-import java.io.ByteArrayOutputStream;
+import java.io.BufferedOutputStream;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
@@ -241,8 +242,30 @@ public final class ConsoleWriterTest {
 		PrintStream originalErrorStream = System.err;
 
 		try {
-			System.setOut(createRecordingPrintStream(writeOrder, "out"));
-			System.setErr(createRecordingPrintStream(writeOrder, "err"));
+			OutputStream outSink = new OutputStream() {
+				@Override
+				public void write(final int b) {
+					write(new byte[] { (byte) b }, 0, 1);
+				}
+
+				@Override
+				public void write(final byte[] buffer, final int offset, final int length) {
+					writeOrder.add("out:" + new String(buffer, offset, length, StandardCharsets.UTF_8));
+				}
+			};
+			OutputStream errSink = new OutputStream() {
+				@Override
+				public void write(final int b) {
+					write(new byte[] { (byte) b }, 0, 1);
+				}
+
+				@Override
+				public void write(final byte[] buffer, final int offset, final int length) {
+					writeOrder.add("err:" + new String(buffer, offset, length, StandardCharsets.UTF_8));
+				}
+			};
+			System.setOut(new PrintStream(new BufferedOutputStream(outSink), false, "UTF-8"));
+			System.setErr(new PrintStream(errSink, true, "UTF-8"));
 
 			ConsoleWriter writer = new ConsoleWriter(singletonMap("format", "{message}"));
 			writer.write(LogEntryBuilder.empty().level(Level.TRACE).message("1 Test Trace").create());
@@ -272,23 +295,13 @@ public final class ConsoleWriterTest {
 		}
 	}
 
-	private static PrintStream createRecordingPrintStream(final List<String> writeOrder, final String label)
-			throws UnsupportedEncodingException {
-		return new PrintStream(new ByteArrayOutputStream(), false, StandardCharsets.UTF_8.name()) {
-			@Override
-			public void write(final byte[] buffer, final int offset, final int length) {
-				writeOrder.add(label + ":" + new String(buffer, offset, length, StandardCharsets.UTF_8));
-			}
-		};
-	}
-
 	/**
 	 * Verifies that an empty logger works correctly.
 	 */
 	@Test
 	public void errorOutputStreamForEmptyLogger() {
 		ConsoleWriter writer = new ConsoleWriter();
-		writer.flush(); // Does nothing but gets coverage for flush
+		writer.flush(); // Flushes buffered console streams
 
 		writer.write(LogEntryBuilder.empty().level(Level.TRACE).message("Hello World!").date(LocalDate.now()).create());
 		assertThat(systemStream.consumeStandardOutput()).contains("Hello World!" + NEW_LINE);

--- a/tinylog-impl/src/test/java/org/tinylog/writers/ConsoleWriterTest.java
+++ b/tinylog-impl/src/test/java/org/tinylog/writers/ConsoleWriterTest.java
@@ -13,7 +13,13 @@
 
 package org.tinylog.writers;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Rule;
@@ -225,6 +231,57 @@ public final class ConsoleWriterTest {
 		assertThat(systemStream.consumeErrorOutput()).contains("Hello World!" + NEW_LINE);
 	}
 	
+	/**
+	 * Verifies that log entries are written in chronological order, even if standard output stream is buffered.
+	 */
+	@Test
+	public void chronologicalOrderWithBufferedStandardOutputStream() throws UnsupportedEncodingException {
+		List<String> writeOrder = new ArrayList<String>();
+		PrintStream originalStandardStream = System.out;
+		PrintStream originalErrorStream = System.err;
+
+		try {
+			System.setOut(createRecordingPrintStream(writeOrder, "out"));
+			System.setErr(createRecordingPrintStream(writeOrder, "err"));
+
+			ConsoleWriter writer = new ConsoleWriter(singletonMap("format", "{message}"));
+			writer.write(LogEntryBuilder.empty().level(Level.TRACE).message("1 Test Trace").create());
+			writer.write(LogEntryBuilder.empty().level(Level.DEBUG).message("2 Test Debug").create());
+			writer.write(LogEntryBuilder.empty().level(Level.INFO).message("3 Test Info").create());
+			writer.write(LogEntryBuilder.empty().level(Level.WARN).message("4 Test Warn").create());
+			writer.write(LogEntryBuilder.empty().level(Level.ERROR).message("5 Test Error").create());
+			writer.write(LogEntryBuilder.empty().level(Level.WARN).message("6 Test Warn").create());
+			writer.write(LogEntryBuilder.empty().level(Level.INFO).message("7 Test Info").create());
+			writer.write(LogEntryBuilder.empty().level(Level.DEBUG).message("8 Test Debug").create());
+			writer.write(LogEntryBuilder.empty().level(Level.TRACE).message("9 Test Trace").create());
+
+			assertThat(writeOrder).containsExactly(
+				"out:1 Test Trace" + NEW_LINE,
+				"out:2 Test Debug" + NEW_LINE,
+				"out:3 Test Info" + NEW_LINE,
+				"err:4 Test Warn" + NEW_LINE,
+				"err:5 Test Error" + NEW_LINE,
+				"err:6 Test Warn" + NEW_LINE,
+				"out:7 Test Info" + NEW_LINE,
+				"out:8 Test Debug" + NEW_LINE,
+				"out:9 Test Trace" + NEW_LINE
+			);
+		} finally {
+			System.setOut(originalStandardStream);
+			System.setErr(originalErrorStream);
+		}
+	}
+
+	private static PrintStream createRecordingPrintStream(final List<String> writeOrder, final String label)
+			throws UnsupportedEncodingException {
+		return new PrintStream(new ByteArrayOutputStream(), false, StandardCharsets.UTF_8.name()) {
+			@Override
+			public void write(final byte[] buffer, final int offset, final int length) {
+				writeOrder.add(label + ":" + new String(buffer, offset, length, StandardCharsets.UTF_8));
+			}
+		};
+	}
+
 	/**
 	 * Verifies that an empty logger works correctly.
 	 */


### PR DESCRIPTION
## Summary

- Fix log entries appearing out of chronological order when using the default `console` writer with mixed severity levels (e.g. TRACE/DEBUG/INFO followed by WARN/ERROR).
- Root cause: `ConsoleWriter` routes WARN and ERROR to `System.err` and lower levels to `System.out`. When `System.out` is block-buffered (common in IDE run consoles and piped output), stderr lines become visible before buffered stdout lines even though they were logged later.
- Flush the target stream after each write and implement `flush()` for both stdout and stderr so entries appear in logging order.

## Test plan

- [x] Added `chronologicalOrderWithBufferedStandardOutputStream` in `ConsoleWriterTest` reproducing the interleaved level sequence from #849 with a non-autoflush stdout stream
- [ ] `mvn clean verify` (requires JDK 9 per CONTRIBUTING.md)

Fixes #849

Made with [Cursor](https://cursor.com)